### PR TITLE
changed image url in annotation experiment to display image name instead of content.

### DIFF
--- a/rapidannotator/modules/annotate_experiment/templates/annotate_experiment/main.html
+++ b/rapidannotator/modules/annotate_experiment/templates/annotate_experiment/main.html
@@ -404,7 +404,7 @@
             if( "{{ experiment.uploadType }}" === "viaSpreadsheet" )
                 var url = fileToLoad.content;
             else
-                var url = "/annotate_experiment/uploads/" + {{experiment.id}} + "/" + fileToLoad.content;
+                var url = "/annotate_experiment/uploads/" + {{experiment.id}} + "/" + fileToLoad.name;
 
             if( "{{ experiment.category }}" === "image") {
                 loadedDiv.find('img').attr('src', url);


### PR DESCRIPTION
Fixes #4 

## Reason behind the issue
- Renaming the image was perfectly saving the image with new name in the database and file storage.
- However, while displaying the image in the front-end, image path was fetched using image content instead of image name. 

## Fixing the issue
- Changed the url to point to image name instead of image content in javascript.

## Screenshots of the fix
![fix1](https://user-images.githubusercontent.com/25129274/53833073-bcbe7000-3fad-11e9-9b9d-235837b5532a.png)
- In the above screenshot we can see an image named **hills.jpg** present under experiment named **Bug-testing**.

![fix_2](https://user-images.githubusercontent.com/25129274/53833314-36eef480-3fae-11e9-9eae-5d1d8d6a23c5.png)

- Renamed the image to **hills_new.jpg**.

![fix_3](https://user-images.githubusercontent.com/25129274/53833331-44a47a00-3fae-11e9-8913-8a2d6f3dc5da.png)

- Signed out and signed in again, able to see the image in annotation page.
