### PR TITLE
Added support for setting up RapidAnnotator using virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Rapid Annotator is built using _Flask (Python Framework) and Javascript (+ Html5
 I have made a GSoC blog, please refer to it for my all GSoC blogposts about the progress made so far.
 Blog link: https://guptavaibhav18197.github.io/GSoC-Blog/
 
-For installtion guide refer [here](https://github.com/guptavaibhav18197/rapidannotator/blob/master/docs/installation_guide.md).
+For installation guide refer [here](https://github.com/RedHenLab/RapidAnnotator-2.0/blob/master/docs/installation_guide.md).
 
 For user guide refer [here](https://github.com/guptavaibhav18197/rapidannotator/blob/master/docs/user_guide.md).

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -14,13 +14,19 @@ following command and then run the above command
 
 Install **python3-mysqldb**.
 
+Install [**virtualenv**](https://virtualenv.pypa.io/en/latest/) using the below command:
+
+`sudo pip3 install virtualenv`
+
 Run
 
 `git clone https://github.com/guptavaibhav18197/rapidannotator.git`
 
 `cd rapidannotator`
 
-`sudo su`
+`virtualenv -p python3 venv`
+
+`source venv/bin/activate`
 
 `pip3 install -r requirements.txt`
 
@@ -49,6 +55,9 @@ Add the following line to listen to port 8000 in `/etc/apache2/ports.conf`
 
 ```Listen 8000```
 
+In the _wsgi.py_ file in the `activate_this` replace the current path i.e.
+
+`[Path_to_virtual_environment]/bin/activate_this.py` to `/path/to/venv`
 
 Next, in _wsgi.py_ file in the rapidannotator replace the current path i.e.
 

--- a/wsgi_template.py
+++ b/wsgi_template.py
@@ -1,3 +1,6 @@
+activate_this = '[Path_to_virtual_environment]/bin/activate_this.py'
+with open(activate_this) as file_:
+    exec(file_.read(), dict(__file__=activate_this))
 import sys
 sys.path.insert(0, '[Path_to_rapidannotator]/rapidannotator')
 


### PR DESCRIPTION
Fixes #11 

## Fixing the issue
- Changed the _wsgi_template.py_ file to make the application run inside a virtual environment.
- Added new instructions for setting up **RapidAnnotator** on **apache2** using virtual environment in _installation_guide.md_