### PR TITLE
Fixed Bug of Not displaying the filenames on result page when the text files have been uploade manually

### DIFF
--- a/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
@@ -630,7 +630,6 @@
 
         category = "{{ experiment.category }}";
         dt = "{{ experiment.display_time }}";
-
         if( dt == "None" && (category  === "audio" || category === "video") ) {
             $('#displayTimeModalId').modal('show');
         }

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
@@ -629,10 +629,9 @@
     $(function() {
 
         category = "{{ experiment.category }}";
-        uploadType = "{{experiment.uploadType}}";
         dt = "{{ experiment.display_time }}";
 
-        if( dt == "None" && uploadType != "manual" && (category  === "audio" || category === "video") ) {
+        if( dt == "None" && (category  === "audio" || category === "video") ) {
             $('#displayTimeModalId').modal('show');
         }
 

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
@@ -629,8 +629,10 @@
     $(function() {
 
         category = "{{ experiment.category }}";
+        uploadType = "{{experiment.uploadType}}";
         dt = "{{ experiment.display_time }}";
-        if( dt == "None" && (category  === "audio" || category === "video") ) {
+
+        if( dt == "None" && uploadType != "manual" && (category  === "audio" || category === "video") ) {
             $('#displayTimeModalId').modal('show');
         }
 

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/results.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/results.html
@@ -84,6 +84,8 @@
                                                 Your browser does not support HTML5 audio.
                                             </audio>
                                             &nbsp;&nbsp;&nbsp;&nbsp;{{ file.name }}
+                                        {%- else -%}
+                                        <span class="glyphicon glyphicon-file" style="font-size:30px;"></span><br>{{file.name}}
                                         {%- endif -%}
                                     {%- endif -%}    
                                 {%- endif -%}
@@ -177,6 +179,8 @@
 
 
 <script charset="utf-8" type="text/javascript">
+
+    console.log("{{expFiles}}");
 
     $(document).ready(function(){
         

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/results.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/results.html
@@ -84,8 +84,6 @@
                                                 Your browser does not support HTML5 audio.
                                             </audio>
                                             &nbsp;&nbsp;&nbsp;&nbsp;{{ file.name }}
-                                        {%- else -%}
-                                        <span class="glyphicon glyphicon-file" style="font-size:30px;"></span><br>{{file.name}}
                                         {%- endif -%}
                                     {%- endif -%}    
                                 {%- endif -%}
@@ -179,8 +177,6 @@
 
 
 <script charset="utf-8" type="text/javascript">
-
-    console.log("{{expFiles}}");
 
     $(document).ready(function(){
         

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/results.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/results.html
@@ -84,6 +84,8 @@
                                                 Your browser does not support HTML5 audio.
                                             </audio>
                                             &nbsp;&nbsp;&nbsp;&nbsp;{{ file.name }}
+                                        {%- else -%}
+                                            <span class="glyphicon glyphicon-file" style="font-size:30px;"></span><br>{{file.name}}
                                         {%- endif -%}
                                     {%- endif -%}    
                                 {%- endif -%}


### PR DESCRIPTION
* When we upload the text files manually, then on the view result page the file names were missing.

![PR_1](https://user-images.githubusercontent.com/28534390/78499897-1bd25380-7771-11ea-82cf-f72b47d6f130.png)

* This bug has been fixed and now the result page looks like the below image:

![PR_2](https://user-images.githubusercontent.com/28534390/78499919-43292080-7771-11ea-80bf-e9b9d172000c.png)
