### PR TITLE
Fixed adding/removing annotators bug

### DIFF
--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -220,7 +220,7 @@
                 </div>
         </div>
     {%- else -%}
-        <img src="{{html}}" alt="Chart" width="600" height="400" class="center">
+        <img src="{{html}}" alt="Chart" width="600" height="400" class="center" id="annotatorsProgressPlot">
     {%- endif -%}
 </div>
 <br><br>
@@ -788,7 +788,7 @@
                     aToAdd.appendTo(liToAdd);
                     liToAdd.appendTo('#addAnnotatorsMenu');
                     $('#annotators').find('a[value=' + currentAnnotator + ']').remove();
-
+                    document.getElementById("annotatorsProgressPlot").src = response.plot
                 }
                 else {
                     location.reload();
@@ -887,9 +887,15 @@
                 if(response.success) {
                     currentSelected.remove();
                     addAnnotatorToList(response.annotatorId, response.annotatorUsername);
+                    document.getElementById("annotatorsProgressPlot").src = response.plot//#image_source_here
+                    // Refreshing the plot only
+
                 }
                 else {
-                    /*do something here*/
+                    displayMessage(response.message);
+                    // This can be replaced with refreshing the list of annotators only
+                    location.reload()
+                    
                 }
             });
             addAnnotatorFeedback(userName);
@@ -973,6 +979,13 @@
             });
         });
 
+        function displayMessage(message){
+            var snackbar = $('#snackbar3');
+            snackbar.text(message)
+            var x = document.getElementById("snackbar3");
+            x.className = "show";
+            setTimeout(function(){ x.className = x.className.replace("show", ""); }, 2500);
+        };
         // Function to display feedback when user is added as annotator of the experiment
         function addAnnotatorFeedback(userName){
             var snackbar = $('#snackbar3');

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -216,9 +216,10 @@
         <div class="info1" style="margin-left: auto; margin-right: auto; display: block; ">
                 <br>
                 <div class="alert alert-info col-md-6" role="alert">
-                    Experiment doesn't have any annotator yet!
+                    Experiment doesn't have any annotators progress yet!
                 </div>
         </div>
+        <img src="{{html}}" alt="Chart" width="600" height="400" class="center" id="annotatorsProgressPlot" style="display:none;">
     {%- else -%}
         <img src="{{html}}" alt="Chart" width="600" height="400" class="center" id="annotatorsProgressPlot">
     {%- endif -%}
@@ -788,7 +789,14 @@
                     aToAdd.appendTo(liToAdd);
                     liToAdd.appendTo('#addAnnotatorsMenu');
                     $('#annotators').find('a[value=' + currentAnnotator + ']').remove();
-                    document.getElementById("annotatorsProgressPlot").src = response.plot
+                    if (response.plot) {
+                        $("#annotatorsProgressPlot").attr('src',response.plot);
+                        $("#annotatorsProgressPlot").show();
+                        }
+                    else {
+                        $("#annotatorsProgressPlot").attr('src',"");
+                        $("#annotatorsProgressPlot").hide();
+                    }
                 }
                 else {
                     location.reload();
@@ -887,7 +895,8 @@
                 if(response.success) {
                     currentSelected.remove();
                     addAnnotatorToList(response.annotatorId, response.annotatorUsername);
-                    document.getElementById("annotatorsProgressPlot").src = response.plot//#image_source_here
+                    $("#annotatorsProgressPlot").attr('src',response.plot);
+                    $("#annotatorsProgressPlot").show();
                     // Refreshing the plot only
 
                 }

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -795,8 +795,8 @@
                     /*do something here*/
                 }
             });
-            location.reload();
-            location.reload();
+            //location.reload();
+            //location.reload();
         })
 
         category = "{{ experiment.category }}";
@@ -893,8 +893,8 @@
                 }
             });
             addAnnotatorFeedback(userName);
-            location.reload();
-            location.reload();
+            //location.reload();
+            //location.reload();
         });
 
         function addOwnerToList(id, name) {


### PR DESCRIPTION
### Description 
This pull requests solves this issue [Unexpected behavior when adding or removing annotators at an experiment #47](https://github.com/RedHenLab/RapidAnnotator-2.0/issues/47)
It is a simple solution as I found the location reloading in unnecessary and making the unexpected behavior because immediate reloading makes the code in an inconsistent state and I didn't get what is their purpose so commenting them fixed that issue.
### Screenshots
#### 1. Firefox is working right now 
![Firefox fixed bug](https://user-images.githubusercontent.com/39674365/120560475-11f2c180-c403-11eb-9415-0e9f6a7a6a38.gif)
#### 2. Making quick adding is working correctly as well as removing, everything is fine. (this on Google Chrome)
![Unexpected behavior on adding annotators](https://user-images.githubusercontent.com/39674365/120560574-3babe880-c403-11eb-8604-6f10ac9db236.gif)
