### PR TITLE
Video Snippet Annotated column added to results exporting at concordance experiments

### DIFF
--- a/rapidannotator/models.py
+++ b/rapidannotator/models.py
@@ -533,7 +533,7 @@ class File(db.Model):
         return 'File <id={0.id}, \
                 Experiment={0.experiment_id}, \
                 name={0.name}, \
-                url={0.url}>'.format(self)
+                content={0.content}>'.format(self)
 
 """
     Modal to store File Captions 

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -1370,6 +1370,9 @@ def _exportResultsConcordance(experiment, format1):
         data.insert(col_num, "Comments by " + annotator.username, comments)
         col_num = col_num + 1
 
+    before_time = experiment.display_time.before_time
+    after_time = experiment.display_time.after_time
+    data['Video Snippet Annotated'] = data['Video Snippet'].apply(lambda video_snippet: _addOffsetTime(video_snippet, before_time, after_time))
     
     if format1 == '.xlsx':
         print(format1)
@@ -1388,6 +1391,36 @@ def _exportResultsConcordance(experiment, format1):
 
     return send_file(filePath, as_attachment=True)
 
+def _addOffsetTime(video_snippet, before_time, after_time):
+    """ Utility function used at exporting concordance results.
+    Modifying offset of the video snippet link
+    by applying the following equations:
+        new_start = video_snippet_start - exp.display_caption.before_time
+        new_end = video_snippet_end + exp.display_caption.after_time
+    and replacing those with the existing on the video snippet using regular expression
+    Args:
+        video_snippet: str. of the link expected to change it's offset
+        before_time: float representes the exp.'s display_caption before_time
+        after_time: float representes the exp.'s display_caption after_time
+    Returns:
+        video_snippet: modified video_snippet start and end times on the link
+    """
+    # If the sent video_snippet is not string, returning it without processing.
+    if not isinstance(video_snippet, str):
+        return video_snippet
+    float_re = "([0-9]*)?[.]?([0-9]*)?"
+    video_time = re.search(f'start=({float_re})&end=({float_re})$', video_snippet)
+    # If the sent video_snippet is not matching the re. so it miss the start and end
+    # Just returns it without any modifications
+    if not video_time:
+        return video_snippet
+    start_time = float(video_time.group(1)) - before_time
+    start_time = 0 if start_time < 0 else start_time
+    end_time = float(video_time.group(2)) + after_time
+    end_time = 0 if end_time < 0 else end_time
+    video_snippet = re.sub(f'end=({float_re})', "end=" + str(end_time), video_snippet)
+    video_snippet = re.sub(f'start=({float_re})', "start=" + str(start_time), video_snippet)
+    return video_snippet
 
 @blueprint.route('/_exportResultsCSV/<int:experimentId>/<string:format1>', methods=['POST','GET'])
 def _exportResultsCSV(experimentId, format1):

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -1369,11 +1369,14 @@ def _exportResultsConcordance(experiment, format1):
         col_num = col_num + 1
         data.insert(col_num, "Comments by " + annotator.username, comments)
         col_num = col_num + 1
-
-    before_time = experiment.display_time.before_time
-    after_time = experiment.display_time.after_time
-    data['Video Snippet Annotated'] = data['Video Snippet'].apply(lambda video_snippet: _addOffsetTime(video_snippet, before_time, after_time))
     
+    if experiment.display_time:
+        before_time = experiment.display_time.before_time
+        after_time = experiment.display_time.after_time
+        data['Video Snippet Annotated'] = data['Video Snippet'].apply(lambda video_snippet: _addOffsetTime(video_snippet, before_time, after_time))
+    else:
+        data['Video Snippet Annotated'] = data['Video Snippet']
+        
     if format1 == '.xlsx':
         print(format1)
         filename = str(experiment.id) + '.xlsx'


### PR DESCRIPTION
### Description 
Added a new column to the concordance experiments exporting results "Video Snippet Annotated" which is simply the same as Video Snippet but with start and end modified based on the experiment's display time [before_time and after_time]
By applying the following equations 
> new_start = video_snippet_start - exp.display_caption.before_time
> new_end = video_snippet_end + exp.display_caption.after_time

and replacing those with the existing on the video snippet using regular expression.

***Kindly review that and if there is any edits needed tell me!***

### Screenshot of an experiment
![VideoAnnotatedSnippet](https://user-images.githubusercontent.com/39674365/123850843-ca385a80-d91a-11eb-91ee-f7e5bf5b02bb.gif)

