### PR TITLE
Continue a specific experiment using exported wide results format feature

### DIFF
--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -327,7 +327,7 @@ def _reorderAnnotationLevels():
     for level in experiment.annotation_levels:
         if order.get(str(level.id),None) == None:
             response = {'success' : False, 'message': "Incompelete annotation levels info"}
-        return jsonify(response)
+            return jsonify(response)
     # Updating each level with its new order
     for level in experiment.annotation_levels:
         level.level_number = order[str(level.id)]

--- a/rapidannotator/modules/home/views.py
+++ b/rapidannotator/modules/home/views.py
@@ -306,7 +306,9 @@ def _continueExperiment():
         'caption' not in resultsFile.columns or \
         'content' not in resultsFile.columns or \
         'edge_link' not in resultsFile.columns or \
-        'display_order' not in resultsFile.columns :
+        'display_order' not in resultsFile.columns or\
+        (experiment.uploadType == "fromConcordance" and \
+        'Number of hit' not in resultsFile.columns):
         # if one of the previous columns are not in the file columns
         # return the following message
         return jsonify({"success": False, "message": "File format is not correct"})

--- a/rapidannotator/modules/home/views.py
+++ b/rapidannotator/modules/home/views.py
@@ -16,7 +16,6 @@ from matplotlib import pyplot as plt
 from io import BytesIO
 import base64
 from rapidannotator import app
-import io   
 import pandas as pd
 from rapidannotator.models import File
 
@@ -292,10 +291,10 @@ def _continueExperiment():
         and experiment.category != "text"\
         and not os.path.exists(experimentDir):
         os.makedirs(experimentDir)
-    # parse csv 
+    # parse csv format
     if fileExt == '.csv':
         resultsFile = pd.read_csv(resultsFile, sep=',')
-    # parse excel
+    # parse excel format
     else:
         resultsFile = pd.read_excel(resultsFile)
         pass
@@ -344,4 +343,4 @@ def _continueExperiment():
         concordance = resultsFile[columns[startConcordance:]]
         outfilePath = os.path.join(experimentDir, "concordance.csv")
         concordance.to_csv(outfilePath, index=False)
-    return jsonify({"success": True})
+    return jsonify({"success": True, "message": "Experiment created successfully."})


### PR DESCRIPTION
### Description
To allow experimenter modifying the results exported file (at wide format) and continue from the point they have edited their results to a new experiment. for example removing a row from the sheet (file)
#### So the following changes has been needed to be added to wide format results export
1. Added all attributes of file (file name, content, concordance line number; for concordance experiments and edge link and rest of them)
2. Merged the concordance file data to the exported results wide format file (in case of it is a concordance uploaded type)
#### So to continue an experiment you need to 
1. Specify which experiment to continue (select box based on your experiments)
2. Upload the exported results in wide format
3. Give it a new name (default: Copy of [old experiment name] [id])
4. Give it a description (default: "")
![image](https://user-images.githubusercontent.com/39674365/125834745-09d723ff-49b8-4846-9d73-32a08a51cb63.png)

#### Effects are same as creating a new experiment based on the old experiment results file

### Screenshots
1. Copy of image experiment
![New copy of an experiment](https://user-images.githubusercontent.com/39674365/125834626-5700530f-1a48-4393-85ce-0bc312f3bff1.gif)

2.Concordance experiment (it creates a new concordance file based on the given results file)
![Copy of concordance](https://user-images.githubusercontent.com/39674365/125834530-5329f257-22f1-4e39-a737-72b476802a7b.gif)

3. Text experiment
![Text Experiment](https://user-images.githubusercontent.com/39674365/125834509-56e2f040-45cc-411c-99de-4fc5bf3be1ec.gif)

> *Kindly review that if there are any changes tell me!*