### PR TITLE
New feature added and modifications on exporting results and solving view results with no annotators issue

### DIFF
--- a/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
@@ -647,7 +647,7 @@
                     uploadedFeedback();
                     var serverResponse = JSON.parse(response.response);
                     $("tr[value=" + file.id + "]").attr("value", serverResponse.fileId);
-                    if ( experimentUploadType == "viaSpreadsheet") {
+                    if ( experimentUploadType == "viaSpreadsheet" || experimentUploadType=="fromConcordance") {
                         location.reload(true);
                     }
                 },

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
@@ -101,7 +101,7 @@
         <div id="filelist">Your browser doesn't have Flash, Silverlight or HTML5 support.</div>
 
     </div>
-{%- elif experiment.uploadType == 'fromConcordance' -%}
+{%- elif experiment.uploadType == 'fromConcordance' and exp_files|count == 0 %}
     <div class="container">
         <div>
             <div style="display: inline-block">
@@ -128,6 +128,7 @@
         </div>
         <div id="filelist">Your browser doesn't have Flash, Silverlight or HTML5 support.</div>
     </div>
+{%- elif experiment.uploadType == 'fromConcordance' and exp_files|count != 0 %}
 
 {%- else -%}
     <div class="container">

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/noResults.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/noResults.html
@@ -23,12 +23,18 @@
 
     <div class="pull-right" style="display: inline-block">
 
-         <div class="dropdown btn-group btn-group-inline btn-space">
-            <button class="btn btn-primary dropdown-toggle" type="button" id="annotatorResult" data-toggle="dropdown">
-                No Annotator
-            </button>
+        {%- set addAnnotatorsURL = url_for('add_experiment.viewSettings', experimentId = experiment.id) %}
+        <div class="btn-group btn-group-inline btn-space">
+            <a class="btn btn-primary dropdown-toggle" href="{{addAnnotatorsURL}}">
+                Add Annotators
+            </a>
         </div>
-
+        {%- set backUrl = url_for('add_experiment.index', experimentId = experiment.id) %}
+        <div class="btn-group btn-group-inline btn-space">
+            <a class="btn btn-primary dropdown-toggle" href="{{backUrl}}">
+                Back to the experiment
+            </a>
+        </div>
         <!-- <a id="discardAnnotationsButtonId" href="" data-target="#discardAnnotations"
             data-toggle="modal" class="btn btn-danger btn-group btn-group-inline
             btn-space">

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -87,12 +87,20 @@
                 {{ ('Change Display Order') }} &nbsp;
             <span class="caret"></span></button>
             <ul class="dropdown-menu scrollable-dropdown" id="changeDisplayOrderMenu" role="menu" aria-labelledby="changeDisplayOrderMenu">
-                <li role="presentation" class="changeOrderType"><a role="menuitem" tabindex="-1" data-order='fcfs'><span>
-                    <span class="glyphicon glyphicon-ok" id="normalOrderSpan"> {{ ('Normal') }} </span>
-                </span></a></li>
-                <li role="presentation" class="changeOrderType"><a role="menuitem" tabindex="-1" data-order='random'><span>
-                    <span class="glyphicon glyphicon-ok" id="randomOrderSpan"> {{ ('Random') }}</span>
-                </span></a></li>
+                <li role="presentation" class="changeOrderType" data-order='fcfs'>
+                    <a role="menuitem" tabindex="-1" data-order='fcfs'>
+                        <span data-order='fcfs'>
+                            <span class="glyphicon glyphicon-ok" id="normalOrderSpan" data-order='fcfs'> {{ ('Normal') }} </span> 
+                        </span>
+                    </a>
+                </li>
+                <li role="presentation" class="changeOrderType" data-order='random'>
+                    <a role="menuitem" tabindex="-1" data-order='random'>
+                        <span data-order='random'>
+                            <span class="glyphicon glyphicon-ok" id="randomOrderSpan" data-order='random'> {{ ('Random') }}</span>
+                        </span>
+                    </a>
+                </li>
             </ul>
         </div>
 
@@ -500,13 +508,8 @@
             }
             var url = "{{ url_for('add_experiment.changeDisplayOrder', experimentId=experiment.id, displayType = newType)}}";
             url += newType
-            console.log(url)
             $.getJSON(url, function(response) {
-                if(response.success) {
-                    
-                } else {
-                    alert(response.msg);
-                }
+                
             });
         });
 

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -507,10 +507,8 @@
                 normalOrder.css('margin-left', '0em');
             }
             var url = "{{ url_for('add_experiment.changeDisplayOrder', experimentId=experiment.id, displayType = newType)}}";
-            url += newType
-            $.getJSON(url, function(response) {
-                
-            });
+            url += newType;
+            $.getJSON(url);
         });
 
         $('.clustering').on('click', function(e) {

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -82,6 +82,20 @@
             </ul>
         </div>
 
+        <div class="dropdown btn-group btn-group-inline btn-space">
+            <button class="btn btn-primary dropdown-toggle" type="button" id="changeDisplayOrder" data-toggle="dropdown">
+                {{ ('Change Display Order') }} &nbsp;
+            <span class="caret"></span></button>
+            <ul class="dropdown-menu scrollable-dropdown" id="changeDisplayOrderMenu" role="menu" aria-labelledby="changeDisplayOrderMenu">
+                <li role="presentation" class="changeOrderType"><a role="menuitem" tabindex="-1" data-order='fcfs'><span>
+                    <span class="glyphicon glyphicon-ok" id="normalOrderSpan"> {{ ('Normal') }} </span>
+                </span></a></li>
+                <li role="presentation" class="changeOrderType"><a role="menuitem" tabindex="-1" data-order='random'><span>
+                    <span class="glyphicon glyphicon-ok" id="randomOrderSpan"> {{ ('Random') }}</span>
+                </span></a></li>
+            </ul>
+        </div>
+
         {%- if (experiment.category == 'audio' or experiment.category == 'video') -%}
             <a data-toggle="modal" data-target="#displayTimeModalId"
                 class="changeDisplayTime btn btn-primary btn-group btn-group-inline btn-space">{{ ('Display Time') }}
@@ -465,6 +479,36 @@
         };
 
         var clustering_status = "{{clustering_status}}";
+        $('.changeOrderType').on('click', function(e){
+            e.preventDefault();
+            newType = e.target.getAttribute('data-order');
+            if (newType == 'random') {
+                removeNormalOrderOkIcon();
+                // add Random Order Ok Icon
+                var randomOrder = $("#randomOrderSpan");
+                randomOrder.addClass('glyphicon');
+                randomOrder.addClass('glyphicon-ok');
+                randomOrder.css('margin-left', '0em');
+            }
+            else {
+                removeRandomOrderOkIcon();
+                // add Normal Order Ok Icon
+                var normalOrder = $("#normalOrderSpan");
+                normalOrder.addClass('glyphicon');
+                normalOrder.addClass('glyphicon-ok');
+                normalOrder.css('margin-left', '0em');
+            }
+            var url = "{{ url_for('add_experiment.changeDisplayOrder', experimentId=experiment.id, displayType = newType)}}";
+            url += newType
+            console.log(url)
+            $.getJSON(url, function(response) {
+                if(response.success) {
+                    
+                } else {
+                    alert(response.msg);
+                }
+            });
+        });
 
         $('.clustering').on('click', function(e) {
             if(clustering_status != 2){
@@ -520,6 +564,24 @@
             noTag.removeClass('glyphicon-ok');
             noTag.css('margin-left', '2em');
 
+        }
+        if("{{experiment.displayType}}" == "fcfs"){
+            removeRandomOrderOkIcon();
+        }
+        else{
+            removeNormalOrderOkIcon();
+        }
+        function removeRandomOrderOkIcon(){
+            var randomOrder = $("#randomOrderSpan");
+            randomOrder.removeClass('glyphicon');
+            randomOrder.removeClass('glyphicon-ok');
+            randomOrder.css('margin-left', '2em');
+        }
+        function removeNormalOrderOkIcon(){
+            var normalOrder = $("#normalOrderSpan");
+            normalOrder.removeClass('glyphicon');
+            normalOrder.removeClass('glyphicon-ok');
+            normalOrder.css('margin-left', '2em');
         }
 
         if(displayCluster == "0"){

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -1631,7 +1631,8 @@ def _exportResultsWide(experimentId, format):
         experimentDIR = os.path.join(app.config['UPLOAD_FOLDER'], str(experiment.id))
         inputConcordance = os.path.join(experimentDIR, 'concordance.csv')
         data = pandas.read_csv(inputConcordance)
-        if "Structure ``text_file''" in data.columns:
+        print("Structure ``text_file''" in data.columns, "Here we go")
+        if "Structure ``text_file''" not in data.columns:
             df.drop(columns=['edge_link'], inplace=True)
         data.index += 1
         df = pd.merge(df, data, how='inner', left_on=['concordance_lineNumber'], right_index=True)

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -1,4 +1,4 @@
-from flask import render_template, flash, redirect, url_for, request, jsonify, \
+from flask import json, render_template, flash, redirect, url_for, request, jsonify, \
     current_app, g, abort, jsonify, session, send_file
 from flask_babelex import lazy_gettext as _
 from sqlalchemy.sql.functions import user
@@ -70,7 +70,7 @@ def index(experimentId):
     notAnnotators = [x for x in users if x not in annotators]
 
     if len(annotators) == 0:
-        firstID = 3000
+        firstID = None
     else:
         firstID = annotators[0].id
 
@@ -1079,13 +1079,14 @@ def _deleteExperiment():
     return jsonify(response)
 
 
+@blueprint.route('/viewResults/<int:experimentId>', defaults={'userId': None})
 @blueprint.route('/viewResults/<int:experimentId>/<int:userId>')
 @isPerimitted2
 def viewResults(experimentId, userId):
     """ Viewing results of a user/annotator's annotation at an experiment.
     Args:
         experimentId: Id of the experiment requested to be viewed.
-        userId: Id of a specific annotator of that experiment.
+        userId: (optional) Id of a specific annotator of that experiment.
         levelId: (optional) Id of annotation level, filtering option.
         labelId: (optional) Id of annotation level's label, filtering option.
     Returns: 
@@ -1096,6 +1097,9 @@ def viewResults(experimentId, userId):
 
     page, per_page, offset = get_page_args(page_parameter='page', per_page_parameter='per_page')
     experiment = Experiment.query.filter_by(id=experimentId).first()
+
+    if (userId == None):
+        return render_template('add_experiment/noResults.html', experiment = experiment)
     
     expFiles = File.query.filter_by(experiment_id=experiment.id).limit(per_page).offset(offset)
 

--- a/rapidannotator/modules/home/views.py
+++ b/rapidannotator/modules/home/views.py
@@ -305,7 +305,6 @@ def _continueExperiment():
     if  'file_name' not in resultsFile.columns or \
         'caption' not in resultsFile.columns or \
         'content' not in resultsFile.columns or \
-        'edge_link' not in resultsFile.columns or \
         'display_order' not in resultsFile.columns or\
         (experiment.uploadType == "fromConcordance" and \
         'Number of hit' not in resultsFile.columns):


### PR DESCRIPTION
## This pull request contains the following
### 1. Solves the problem of viewing results of an experiment while it has no annotators 
> this due to the hard coded id sent when len(annotators) = 0 at line 73 @RapidAnnotator-2.0/rapidannotator/modules/add_experiment/views.py 
#### Before
![NotcorrectViewResults](https://user-images.githubusercontent.com/39674365/128640470-dfa621c6-3d92-4662-8562-c90f88b779ef.gif)
#### After
![AfterBeingFixed](https://user-images.githubusercontent.com/39674365/128641883-a46a1dc9-ef6c-457c-baa8-65c98bbb755b.gif)

### 2. Allowing experiment's order to be modified between normal and random
> ![changeorder](https://user-images.githubusercontent.com/39674365/128642586-0fcffabd-9a3c-4ecb-b891-558ec3753213.gif)

### 3. Disabled uploading once the experiment has already a done uploaded concordance file
![newconcordanceupload](https://user-images.githubusercontent.com/39674365/128645055-b07a9cac-1d27-4c45-88a2-700fad3877bd.gif)

### 4. Exporting results of concordance at wide format will be only contains the edge link if it is new scape type
![newscapecheck](https://user-images.githubusercontent.com/39674365/128646843-be8ad70f-9d7f-4655-9142-31de57aa0900.gif)

## Kindly review that and tell me if there are any further modifications needed 

