### PR TITLE
 Annotations adds-on (coordinates feature)

### DIFF
--- a/rapidannotator/modules/add_experiment/templates/add_experiment/labels.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/labels.html
@@ -6,6 +6,21 @@
   {{ super() }}
   <style type="text/css">
     .important { color: #336699; }
+    #sortable { 
+        list-style-type: square; 
+        margin: 1rem; 
+        padding: 1rem; 
+    }
+    #sortable li{
+        margin: 0.3em; 
+        padding: 0.5em 1em 0.5em 1em; 
+        font-size: 1.3em;
+        cursor: move;
+        border-left: 6px solid #ccc;
+        border-color: palevioletred;
+        color: #000;
+        background-color: ghostwhit;
+    }
   </style>
 {% endblock head %}
 
@@ -35,6 +50,10 @@
                 {{ ('Make Global') }}
             </button>
         <!-- </button> -->
+        <button type="button"
+                class="btn btn-primary btn-group btn-group-inline btn-space" id="showReorderModal">
+                {{ ('Reorder Annotation Levels') }}
+        </button>
         <a href="{{ url_for('add_experiment._importAnnotationtLevel', experimentId = experiment.id) }}" 
             class="btn btn-primary btn-group btn-group-inline btn-space">{{ ('Import Existing Levels') }}
         </a>
@@ -55,6 +74,7 @@
                 <div class="col-xs-12">
                     <div class="annotationDescriptionGrp">
                         <span class="col-xs-4 h5 wrapWord annotationName"><b>Annotation Level Name</b>: <span>{{ annotation_level.name }}</span></span>
+                        <span class="col-xs-4 h5 wrapWord annotationNumber"><b>Annotation Level Number</b>: <span id="levelnumber-{{annotation_level.id}}">{{ annotation_level.level_number }}</span></span>
                         <span class="col-xs-7 h5 annotationDescription"><b>Description</b>:<span>{{ annotation_level.description }}</span></span>
                         <span class="annotationLevelInstruction hidden-element">{{annotation_level.instruction }}</span>
                         
@@ -376,9 +396,67 @@
   </div>
 </div>
 
+
+<!-- Reorder-Annotation-Levels-Modal -->
+<div class="modal fade" id="reorderLevels" role="dialog" tabindex="-1"
+    aria-labelledby="reorderLevels" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h4 class="modal-title">Reoder Annotation Levels</h4>
+      </div>
+        <div class="modal-body">
+            <span class="help-block">
+            Drag and drop the annotation levels to reorder them as you wish
+            </span>
+            <ul id="sortable">
+                {% for annotation_level in annotation_levels %}
+                    <li class="ui-state-default" 
+                    data-levelnumber={{annotation_level.level_number}} 
+                    data-id={{annotation_level.id}}>
+                        {{ annotation_level.name }}
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
+            <button type="submit" class="btn btn-primary" id="saveOrderingBtn"> Save new ordering </button>
+        </div>
+    </div>
+  </div>
+</div>
+
 <script charset="utf-8" type="text/javascript">
 
     $(function() {
+        // For reordering levels functionality
+        $("#saveOrderingBtn").on("click", function(){
+            data = {order:{}, experimentId: {{experiment.id}}}
+            $("#sortable li").each(function(index, value) {
+                data.order[this.dataset.id] = index+1;
+                $(`#levelnumber-${this.dataset.id}`).text(index+1);
+            });
+            var url = "{{ url_for('add_experiment._reorderAnnotationLevels')}}";
+            data = JSON.stringify(data)
+            $.post(url , data, function(response) {
+                if(response.success)
+                    location.reload();
+                else
+                    alert("Something gone wrong please try later!");
+            });
+            $("#reorderLevels").modal("hide");
+        });
+        $("#showReorderModal").on("click", function(){
+            $("#reorderLevels").modal("show");
+        });
+        $("#sortable").sortable({
+            change: function(event, ui) {
+                console.log(event);
+            }
+        });
+        $("#sortable").disableSelection();
 
         var errors = "{{errors}}";
         if( "{{ errors }}" == "annotationLevelErrors") {
@@ -734,6 +812,7 @@
             selectedAnnotation.find('.annotationDescription span').text(description);
             selectedAnnotation.find('.annotationLevelInstruction').text(instruction);
             selectedAnnotation.data('level',levelNumber);
+            $(`#levelnumber-${selectedAnnotationId}`).text(levelNumber);
         }
 
         function deleteAsync(labelId, annotationId) {

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
@@ -647,7 +647,7 @@
                     uploadedFeedback();
                     var serverResponse = JSON.parse(response.response);
                     $("tr[value=" + file.id + "]").attr("value", serverResponse.fileId);
-                    if ( experimentUploadType == "viaSpreadsheet") {
+                    if ( experimentUploadType == "viaSpreadsheet" || experimentUploadType=="fromConcordance") {
                         location.reload(true);
                     }
                 },

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
@@ -101,7 +101,7 @@
         <div id="filelist">Your browser doesn't have Flash, Silverlight or HTML5 support.</div>
 
     </div>
-{%- elif experiment.uploadType == 'fromConcordance' -%}
+{%- elif experiment.uploadType == 'fromConcordance' and exp_files|count == 0 %}
     <div class="container">
         <div>
             <div style="display: inline-block">
@@ -128,6 +128,7 @@
         </div>
         <div id="filelist">Your browser doesn't have Flash, Silverlight or HTML5 support.</div>
     </div>
+{%- elif experiment.uploadType == 'fromConcordance' and exp_files|count != 0 %}
 
 {%- else -%}
     <div class="container">

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/noResults.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/noResults.html
@@ -23,12 +23,18 @@
 
     <div class="pull-right" style="display: inline-block">
 
-         <div class="dropdown btn-group btn-group-inline btn-space">
-            <button class="btn btn-primary dropdown-toggle" type="button" id="annotatorResult" data-toggle="dropdown">
-                No Annotator
-            </button>
+        {%- set addAnnotatorsURL = url_for('add_experiment.viewSettings', experimentId = experiment.id) %}
+        <div class="btn-group btn-group-inline btn-space">
+            <a class="btn btn-primary dropdown-toggle" href="{{addAnnotatorsURL}}">
+                Add Annotators
+            </a>
         </div>
-
+        {%- set backUrl = url_for('add_experiment.index', experimentId = experiment.id) %}
+        <div class="btn-group btn-group-inline btn-space">
+            <a class="btn btn-primary dropdown-toggle" href="{{backUrl}}">
+                Back to the experiment
+            </a>
+        </div>
         <!-- <a id="discardAnnotationsButtonId" href="" data-target="#discardAnnotations"
             data-toggle="modal" class="btn btn-danger btn-group btn-group-inline
             btn-space">

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/results.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/results.html
@@ -22,8 +22,8 @@
 
 
     <div class="pull-right" style="display: inline-block">
-
-         <div class="dropdown btn-group btn-group-inline btn-space">
+        <!-- Annotators selection box -->
+        <div class="dropdown btn-group btn-group-inline btn-space">
             <button class="btn btn-primary dropdown-toggle" type="button" id="annotatorResult" data-toggle="dropdown">
                 {{user.username}}
             <span class="caret"></span></button>
@@ -35,7 +35,37 @@
                 
             </ul>
         </div>
-
+        <!-- Levels selection box -->
+        <div class="dropdown btn-group btn-group-inline btn-space">
+            <button class="btn btn-primary dropdown-toggle" type="button" id="levelsResult" data-toggle="dropdown">
+                {{ selected_level.name or "All levels" }}
+            <span class="caret"></span></button>
+            <ul class="dropdown-menu scrollable-dropdown" id="levelsResultMenu" role="menu" aria-labelledby="levelsResult">
+                {%- set viewResults = url_for('add_experiment.viewResults', experimentId = experiment.id, userId = user.id) %}
+                <li role="presentation"><a role="menuitem" tabindex="-1" href="{{viewResults}}"><span>All levels</span></a></li>
+                {% for level in annotation_levels %}
+                    {%- set viewResults = url_for('add_experiment.viewResults', experimentId = experiment.id, userId = user.id, levelId=level.id) %}
+                    <li role="presentation"><a role="menuitem" tabindex="-1" href="{{viewResults}}"><span>{{level.name}}</span></a></li>
+                {% endfor %}
+            </ul>
+        </div>
+        <!-- Labels selection box -->
+        <div class="dropdown btn-group btn-group-inline btn-space">
+            <button class="btn btn-primary dropdown-toggle" type="button" id="labelsResult" data-toggle="dropdown">
+                {{selected_label.name or "All labels"}}
+            <span class="caret"></span></button>
+            <ul class="dropdown-menu scrollable-dropdown" id="labelsResultMenu" role="menu" aria-labelledby="labelsResult">
+                {%if selected_level%}
+                {%- set viewResults = url_for('add_experiment.viewResults', experimentId = experiment.id, userId = user.id, levelId=selected_level.id) %}
+                {% endif %}
+                <li role="presentation"><a role="menuitem" tabindex="-1" href="{{viewResults}}"><span>All labels</span></a></li>
+                {% for label in selected_level.labels %}
+                    {%- set viewResults = url_for('add_experiment.viewResults', experimentId = experiment.id, userId = user.id, levelId=selected_level.id, labelId=label.id) %}
+                    <li role="presentation"><a role="menuitem" tabindex="-1" href="{{viewResults}}"><span>{{label.name}}</span></a></li>
+                {% endfor %}
+            </ul>
+        </div>
+        
         <a id="discardAnnotationsButtonId" href="" data-target="#discardAnnotations"
             data-toggle="modal" class="btn btn-danger btn-group btn-group-inline
             btn-space">

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -87,12 +87,20 @@
                 {{ ('Change Display Order') }} &nbsp;
             <span class="caret"></span></button>
             <ul class="dropdown-menu scrollable-dropdown" id="changeDisplayOrderMenu" role="menu" aria-labelledby="changeDisplayOrderMenu">
-                <li role="presentation" class="changeOrderType"><a role="menuitem" tabindex="-1" data-order='fcfs'><span>
-                    <span class="glyphicon glyphicon-ok" id="normalOrderSpan"> {{ ('Normal') }} </span>
-                </span></a></li>
-                <li role="presentation" class="changeOrderType"><a role="menuitem" tabindex="-1" data-order='random'><span>
-                    <span class="glyphicon glyphicon-ok" id="randomOrderSpan"> {{ ('Random') }}</span>
-                </span></a></li>
+                <li role="presentation" class="changeOrderType" data-order='fcfs'>
+                    <a role="menuitem" tabindex="-1" data-order='fcfs'>
+                        <span data-order='fcfs'>
+                            <span class="glyphicon glyphicon-ok" id="normalOrderSpan" data-order='fcfs'> {{ ('Normal') }} </span> 
+                        </span>
+                    </a>
+                </li>
+                <li role="presentation" class="changeOrderType" data-order='random'>
+                    <a role="menuitem" tabindex="-1" data-order='random'>
+                        <span data-order='random'>
+                            <span class="glyphicon glyphicon-ok" id="randomOrderSpan" data-order='random'> {{ ('Random') }}</span>
+                        </span>
+                    </a>
+                </li>
             </ul>
         </div>
 
@@ -500,13 +508,8 @@
             }
             var url = "{{ url_for('add_experiment.changeDisplayOrder', experimentId=experiment.id, displayType = newType)}}";
             url += newType
-            console.log(url)
             $.getJSON(url, function(response) {
-                if(response.success) {
-                    
-                } else {
-                    alert(response.msg);
-                }
+                
             });
         });
 

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -213,7 +213,7 @@
     <h4 style="text-align:center"> Experiment Progress </h4>
     <hr>
     {%- if displayImg == 0 -%}
-        <div class="info1" style="margin-left: auto; margin-right: auto; display: block; ">
+        <div class="info1" style="margin-left: auto; margin-right: auto; display: block; " id="noprogressAlert">
                 <br>
                 <div class="alert alert-info col-md-6" role="alert">
                     Experiment doesn't have any annotators progress yet!
@@ -221,6 +221,12 @@
         </div>
         <img src="{{html}}" alt="Chart" width="600" height="400" class="center" id="annotatorsProgressPlot" style="display:none;">
     {%- else -%}
+       <div class="info1" style="margin-left: auto; margin-right: auto; display: none;" id="noprogressAlert">
+                <br>
+                <div class="alert alert-info col-md-6" role="alert">
+                    Experiment doesn't have any annotators progress yet!
+                </div>
+        </div>
         <img src="{{html}}" alt="Chart" width="600" height="400" class="center" id="annotatorsProgressPlot">
     {%- endif -%}
 </div>
@@ -792,10 +798,12 @@
                     if (response.plot) {
                         $("#annotatorsProgressPlot").attr('src',response.plot);
                         $("#annotatorsProgressPlot").show();
+                        $("#noprogressAlert").hide();
                         }
                     else {
                         $("#annotatorsProgressPlot").attr('src',"");
                         $("#annotatorsProgressPlot").hide();
+                        $("#noprogressAlert").show();
                     }
                 }
                 else {
@@ -897,6 +905,7 @@
                     addAnnotatorToList(response.annotatorId, response.annotatorUsername);
                     $("#annotatorsProgressPlot").attr('src',response.plot);
                     $("#annotatorsProgressPlot").show();
+                    $("#noprogressAlert").hide();
                     // Refreshing the plot only
 
                 }

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -507,10 +507,8 @@
                 normalOrder.css('margin-left', '0em');
             }
             var url = "{{ url_for('add_experiment.changeDisplayOrder', experimentId=experiment.id, displayType = newType)}}";
-            url += newType
-            $.getJSON(url, function(response) {
-                
-            });
+            url += newType;
+            $.getJSON(url);
         });
 
         $('.clustering').on('click', function(e) {

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -216,9 +216,10 @@
         <div class="info1" style="margin-left: auto; margin-right: auto; display: block; ">
                 <br>
                 <div class="alert alert-info col-md-6" role="alert">
-                    Experiment doesn't have any annotator yet!
+                    Experiment doesn't have any annotators progress yet!
                 </div>
         </div>
+        <img src="{{html}}" alt="Chart" width="600" height="400" class="center" id="annotatorsProgressPlot" style="display:none;">
     {%- else -%}
         <img src="{{html}}" alt="Chart" width="600" height="400" class="center" id="annotatorsProgressPlot">
     {%- endif -%}
@@ -788,7 +789,14 @@
                     aToAdd.appendTo(liToAdd);
                     liToAdd.appendTo('#addAnnotatorsMenu');
                     $('#annotators').find('a[value=' + currentAnnotator + ']').remove();
-                    document.getElementById("annotatorsProgressPlot").src = response.plot
+                    if (response.plot) {
+                        $("#annotatorsProgressPlot").attr('src',response.plot);
+                        $("#annotatorsProgressPlot").show();
+                        }
+                    else {
+                        $("#annotatorsProgressPlot").attr('src',"");
+                        $("#annotatorsProgressPlot").hide();
+                    }
                 }
                 else {
                     location.reload();
@@ -887,7 +895,8 @@
                 if(response.success) {
                     currentSelected.remove();
                     addAnnotatorToList(response.annotatorId, response.annotatorUsername);
-                    document.getElementById("annotatorsProgressPlot").src = response.plot//#image_source_here
+                    $("#annotatorsProgressPlot").attr('src',response.plot);
+                    $("#annotatorsProgressPlot").show();
                     // Refreshing the plot only
 
                 }

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -82,6 +82,20 @@
             </ul>
         </div>
 
+        <div class="dropdown btn-group btn-group-inline btn-space">
+            <button class="btn btn-primary dropdown-toggle" type="button" id="changeDisplayOrder" data-toggle="dropdown">
+                {{ ('Change Display Order') }} &nbsp;
+            <span class="caret"></span></button>
+            <ul class="dropdown-menu scrollable-dropdown" id="changeDisplayOrderMenu" role="menu" aria-labelledby="changeDisplayOrderMenu">
+                <li role="presentation" class="changeOrderType"><a role="menuitem" tabindex="-1" data-order='fcfs'><span>
+                    <span class="glyphicon glyphicon-ok" id="normalOrderSpan"> {{ ('Normal') }} </span>
+                </span></a></li>
+                <li role="presentation" class="changeOrderType"><a role="menuitem" tabindex="-1" data-order='random'><span>
+                    <span class="glyphicon glyphicon-ok" id="randomOrderSpan"> {{ ('Random') }}</span>
+                </span></a></li>
+            </ul>
+        </div>
+
         {%- if (experiment.category == 'audio' or experiment.category == 'video') -%}
             <a data-toggle="modal" data-target="#displayTimeModalId"
                 class="changeDisplayTime btn btn-primary btn-group btn-group-inline btn-space">{{ ('Display Time') }}
@@ -465,6 +479,36 @@
         };
 
         var clustering_status = "{{clustering_status}}";
+        $('.changeOrderType').on('click', function(e){
+            e.preventDefault();
+            newType = e.target.getAttribute('data-order');
+            if (newType == 'random') {
+                removeNormalOrderOkIcon();
+                // add Random Order Ok Icon
+                var randomOrder = $("#randomOrderSpan");
+                randomOrder.addClass('glyphicon');
+                randomOrder.addClass('glyphicon-ok');
+                randomOrder.css('margin-left', '0em');
+            }
+            else {
+                removeRandomOrderOkIcon();
+                // add Normal Order Ok Icon
+                var normalOrder = $("#normalOrderSpan");
+                normalOrder.addClass('glyphicon');
+                normalOrder.addClass('glyphicon-ok');
+                normalOrder.css('margin-left', '0em');
+            }
+            var url = "{{ url_for('add_experiment.changeDisplayOrder', experimentId=experiment.id, displayType = newType)}}";
+            url += newType
+            console.log(url)
+            $.getJSON(url, function(response) {
+                if(response.success) {
+                    
+                } else {
+                    alert(response.msg);
+                }
+            });
+        });
 
         $('.clustering').on('click', function(e) {
             if(clustering_status != 2){
@@ -520,6 +564,24 @@
             noTag.removeClass('glyphicon-ok');
             noTag.css('margin-left', '2em');
 
+        }
+        if("{{experiment.displayType}}" == "fcfs"){
+            removeRandomOrderOkIcon();
+        }
+        else{
+            removeNormalOrderOkIcon();
+        }
+        function removeRandomOrderOkIcon(){
+            var randomOrder = $("#randomOrderSpan");
+            randomOrder.removeClass('glyphicon');
+            randomOrder.removeClass('glyphicon-ok');
+            randomOrder.css('margin-left', '2em');
+        }
+        function removeNormalOrderOkIcon(){
+            var normalOrder = $("#normalOrderSpan");
+            normalOrder.removeClass('glyphicon');
+            normalOrder.removeClass('glyphicon-ok');
+            normalOrder.css('margin-left', '2em');
         }
 
         if(displayCluster == "0"){

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -220,7 +220,8 @@ def _displayTargetCaption():
 def editLabels(experimentId):
 
     experiment = Experiment.query.filter_by(id=experimentId).first()
-    annotation_levels = experiment.annotation_levels
+    annotation_levels = AnnotationLevel.query.filter_by(experiment_id=\
+                        experimentId).order_by(AnnotationLevel.level_number)
     annotationLevelForm = AnnotationLevelForm(experimentId = experimentId)
     annotationInfo = AnnotatorAssociation.query.filter_by(experiment_id=experimentId, user_id=current_user.id)
     if annotationInfo.count() > 0:
@@ -304,6 +305,23 @@ def _addAnnotationLevel():
         skipLevel = skipLevel,
         errors = errors,
     )
+@blueprint.route('/_reorderAnnotationLevels', methods=['POST'])
+def _reorderAnnotationLevels():
+    data = request.get_json(force=True)
+    order = data.get('order')
+    print(order)
+    experimentId = data.get('experimentId')
+    experiment = Experiment.query.filter_by(id=experimentId).first()
+    if not experiment or not isinstance(order,dict):
+        response = {'success' : False, 'message': "Incorrect request parameters"}
+    else:
+        for level in experiment.annotation_levels:
+            level.level_number = order[str(level.id)]
+        db.session.commit()
+    response = {
+        'success' : True,
+    }
+    return jsonify(response)
 
 @blueprint.route('/_addLabels', methods=['POST','GET'])
 def _addLabels():

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -1631,7 +1631,8 @@ def _exportResultsWide(experimentId, format):
         experimentDIR = os.path.join(app.config['UPLOAD_FOLDER'], str(experiment.id))
         inputConcordance = os.path.join(experimentDIR, 'concordance.csv')
         data = pandas.read_csv(inputConcordance)
-        if "Structure ``text_file''" in data.columns:
+        print("Structure ``text_file''" in data.columns, "Here we go")
+        if "Structure ``text_file''" not in data.columns:
             df.drop(columns=['edge_link'], inplace=True)
         data.index += 1
         df = pd.merge(df, data, how='inner', left_on=['concordance_lineNumber'], right_index=True)

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -1467,10 +1467,10 @@ def _exportResultsCSV(experimentId, format1):
         csv_data.append(csv_row)
     
     fd = pandas.DataFrame(csv_data, columns=column_headers)
-
+    
+    from rapidannotator import app
     if format1 == '.xlsx':
         filename = str(experimentId) + '.xlsx'
-        from rapidannotator import app
         filePath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         with pandas.ExcelWriter(filePath, date_format='YYYY-MM-DD', datetime_format='YYYY-MM-DD HH:MM:SS') as writer:
             fd.to_excel(writer, sheet_name='Sheet1', index=False)

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -1070,21 +1070,12 @@ def viewResults(experimentId, userId):
 
     from math import ceil
     total = ceil(File.query.filter_by(experiment_id=experiment.id).count() / per_page)
-    exp_files = []
-
     pagination = Pagination(page=page, per_page=per_page, total=total, css_framework='bootstrap3')
-    
+
     annotations = {}
-
-    if userId == 3000:
-        return render_template('add_experiment/noResults.html', exp_files=exp_files, page=page, \
-        per_page=per_page, pagination=pagination, experiment = experiment, annotations = annotations, annotators=annotators)
-
     user = User.query.filter_by(id=userId).first()
-
     for f in expFiles:
         annotation = {}
-        labelDict = {}
         fileAnnotations = AnnotationInfo.query.filter_by(file_id=f.id, user_id=userId)
         if fileAnnotations.count() == 0:
             annotations[f.id] = annotation
@@ -1099,8 +1090,6 @@ def viewResults(experimentId, userId):
                             annotation[level.id] = label.name
                 else:
                     annotation[level.id] = "SKIPPED"
-                    # for label in level.labels:
-                        # annotation[level.id][label.id] = "SKIP"                    
         annotations[f.id] = annotation       
     
     return render_template('add_experiment/results.html', exp_files=expFiles, page=page, \

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -9,6 +9,7 @@ from rapidannotator.models import User, Experiment, AnnotatorAssociation, Annota
 from rapidannotator.modules.add_experiment import blueprint
 from rapidannotator.modules.add_experiment.forms import AnnotationLevelForm
 from rapidannotator import bcrypt
+from math import ceil
 
 from flask_login import current_user, login_required
 from flask_login import login_user, logout_user, current_user
@@ -46,7 +47,6 @@ def index(experimentId):
     for fl in expFiles:
         fileCaption = FileCaption.query.filter_by(file_id=fl.id).first()
         exp_files.append((fl, fileCaption))
-    from math import ceil
     total = ceil(File.query.filter_by(experiment_id=experiment.id).count() / per_page)
 
     pagination = Pagination(page=page, per_page=per_page, total=total, css_framework='bootstrap3')
@@ -1068,7 +1068,6 @@ def viewResults(experimentId, userId):
     annotators_assoc = experiment.annotators
     annotators = [assoc.annotator for assoc in annotators_assoc]
 
-    from math import ceil
     total = ceil(File.query.filter_by(experiment_id=experiment.id).count() / per_page)
     pagination = Pagination(page=page, per_page=per_page, total=total, css_framework='bootstrap3')
 

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -1096,13 +1096,12 @@ def viewResults(experimentId, userId):
     elif not selected_label:
         expFiles = File.query.filter_by(experiment_id=experiment.id)\
             .join(AnnotationInfo, AnnotationInfo.file_id == File.id)\
-            .filter_by(annotationLevel_id = selected_level.id)\
+            .filter_by(annotationLevel_id = selected_level.id, user_id = userId)\
             .limit(per_page).offset(offset)
     else:
         expFiles = File.query.filter_by(experiment_id=experiment.id)\
             .join(AnnotationInfo, AnnotationInfo.file_id == File.id)\
-            .filter_by(annotationLevel_id = selected_level.id)\
-            .filter_by(label_id = selected_label.id)\
+            .filter_by(annotationLevel_id = selected_level.id, user_id = userId, label_id = selected_label.id)\
             .limit(per_page).offset(offset)
 
     annotators_assoc = experiment.annotators

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -41,13 +41,14 @@ def index(experimentId):
     users = User.query.all()
     experiment = Experiment.query.filter_by(id=experimentId).first()
     page, per_page, offset = get_page_args(page_parameter='page', per_page_parameter='per_page')
-    expFiles = File.query.filter_by(experiment_id=experiment.id).all()
+    expFiles = File.query.filter_by(experiment_id=experiment.id).limit(per_page).offset(offset)
     exp_files = []
     for fl in expFiles:
         fileCaption = FileCaption.query.filter_by(file_id=fl.id).first()
         exp_files.append((fl, fileCaption))
-    pagination_files = exp_files[offset: offset + per_page]
-    total = len(exp_files)
+    from math import ceil
+    total = ceil(File.query.filter_by(experiment_id=experiment.id).count() / per_page)
+
     pagination = Pagination(page=page, per_page=per_page, total=total, css_framework='bootstrap3')
 
     
@@ -74,7 +75,7 @@ def index(experimentId):
         experiment = experiment,
         notOwners = notOwners,
         notAnnotators = notAnnotators,
-        exp_files=pagination_files, page=page,
+        exp_files=exp_files, page=page,
         per_page=per_page, pagination=pagination,
         firstID=firstID,
     )
@@ -1061,30 +1062,27 @@ def viewResults(experimentId, userId):
     page, per_page, offset = get_page_args(page_parameter='page', per_page_parameter='per_page')
     experiment = Experiment.query.filter_by(id=experimentId).first()
     
-    expFiles = File.query.filter_by(experiment_id=experiment.id).all()
-    
+    expFiles = File.query.filter_by(experiment_id=experiment.id).limit(per_page).offset(offset)
     annotation_levels = experiment.annotation_levels
     
     annotators_assoc = experiment.annotators
     annotators = [assoc.annotator for assoc in annotators_assoc]
 
-    
+    from math import ceil
+    total = ceil(File.query.filter_by(experiment_id=experiment.id).count() / per_page)
     exp_files = []
-    for fl in expFiles:
-        exp_files.append(fl)
-    pagination_files = exp_files[offset: offset + per_page]
-    total = len(exp_files)
+
     pagination = Pagination(page=page, per_page=per_page, total=total, css_framework='bootstrap3')
     
     annotations = {}
 
     if userId == 3000:
-        return render_template('add_experiment/noResults.html', exp_files=pagination_files, page=page, \
+        return render_template('add_experiment/noResults.html', exp_files=exp_files, page=page, \
         per_page=per_page, pagination=pagination, experiment = experiment, annotations = annotations, annotators=annotators)
 
     user = User.query.filter_by(id=userId).first()
 
-    for f in experiment.files:
+    for f in expFiles:
         annotation = {}
         labelDict = {}
         fileAnnotations = AnnotationInfo.query.filter_by(file_id=f.id, user_id=userId)
@@ -1105,7 +1103,7 @@ def viewResults(experimentId, userId):
                         # annotation[level.id][label.id] = "SKIP"                    
         annotations[f.id] = annotation       
     
-    return render_template('add_experiment/results.html', exp_files=pagination_files, page=page, \
+    return render_template('add_experiment/results.html', exp_files=expFiles, page=page, \
         per_page=per_page, pagination=pagination, experiment = experiment, annotations = annotations, annotators=annotators, user=user)
 
 

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -307,17 +307,31 @@ def _addAnnotationLevel():
     )
 @blueprint.route('/_reorderAnnotationLevels', methods=['POST'])
 def _reorderAnnotationLevels():
+    """ Reordering the annotation levels
+    Request Args:
+        data: dict. contains each annoationlevel as key and its new order as value
+        experimentId: the experiment id to be edited
+    Returns:
+        response: {success:True} when it is has updated 
+        and {success:False} when something is missed from the expected inputs.
+    """
     data = request.get_json(force=True)
     order = data.get('order')
-    print(order)
     experimentId = data.get('experimentId')
     experiment = Experiment.query.filter_by(id=experimentId).first()
+    # Checks whether experimentId is okay and ordering info is compelete or not
     if not experiment or not isinstance(order,dict):
         response = {'success' : False, 'message': "Incorrect request parameters"}
-    else:
-        for level in experiment.annotation_levels:
-            level.level_number = order[str(level.id)]
-        db.session.commit()
+        return jsonify(response)
+    # Making sure each level is given with its new order
+    for level in experiment.annotation_levels:
+        if order.get(str(level.id),None) == None:
+            response = {'success' : False, 'message': "Incompelete annotation levels info"}
+        return jsonify(response)
+    # Updating each level with its new order
+    for level in experiment.annotation_levels:
+        level.level_number = order[str(level.id)]
+    db.session.commit()
     response = {
         'success' : True,
     }

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -1,4 +1,4 @@
-from flask import render_template, flash, redirect, url_for, request, jsonify, \
+from flask import json, render_template, flash, redirect, url_for, request, jsonify, \
     current_app, g, abort, jsonify, session, send_file
 from flask_babelex import lazy_gettext as _
 from sqlalchemy.sql.functions import user
@@ -70,7 +70,7 @@ def index(experimentId):
     notAnnotators = [x for x in users if x not in annotators]
 
     if len(annotators) == 0:
-        firstID = 3000
+        firstID = None
     else:
         firstID = annotators[0].id
 
@@ -1079,13 +1079,14 @@ def _deleteExperiment():
     return jsonify(response)
 
 
+@blueprint.route('/viewResults/<int:experimentId>', defaults={'userId': None})
 @blueprint.route('/viewResults/<int:experimentId>/<int:userId>')
 @isPerimitted2
 def viewResults(experimentId, userId):
     """ Viewing results of a user/annotator's annotation at an experiment.
     Args:
         experimentId: Id of the experiment requested to be viewed.
-        userId: Id of a specific annotator of that experiment.
+        userId: (optional) Id of a specific annotator of that experiment.
         levelId: (optional) Id of annotation level, filtering option.
         labelId: (optional) Id of annotation level's label, filtering option.
     Returns: 
@@ -1096,6 +1097,9 @@ def viewResults(experimentId, userId):
 
     page, per_page, offset = get_page_args(page_parameter='page', per_page_parameter='per_page')
     experiment = Experiment.query.filter_by(id=experimentId).first()
+
+    if (userId == None):
+        return render_template('add_experiment/noResults.html', experiment = experiment)
     
     expFiles = File.query.filter_by(experiment_id=experiment.id).limit(per_page).offset(offset)
 

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -327,7 +327,7 @@ def _reorderAnnotationLevels():
     for level in experiment.annotation_levels:
         if order.get(str(level.id),None) == None:
             response = {'success' : False, 'message': "Incompelete annotation levels info"}
-        return jsonify(response)
+            return jsonify(response)
     # Updating each level with its new order
     for level in experiment.annotation_levels:
         level.level_number = order[str(level.id)]

--- a/rapidannotator/modules/home/views.py
+++ b/rapidannotator/modules/home/views.py
@@ -305,7 +305,6 @@ def _continueExperiment():
     if  'file_name' not in resultsFile.columns or \
         'caption' not in resultsFile.columns or \
         'content' not in resultsFile.columns or \
-        'edge_link' not in resultsFile.columns or \
         'display_order' not in resultsFile.columns or\
         (experiment.uploadType == "fromConcordance" and \
         'Number of hit' not in resultsFile.columns):

--- a/rapidannotator/modules/home/views.py
+++ b/rapidannotator/modules/home/views.py
@@ -306,7 +306,9 @@ def _continueExperiment():
         'caption' not in resultsFile.columns or \
         'content' not in resultsFile.columns or \
         'edge_link' not in resultsFile.columns or \
-        'display_order' not in resultsFile.columns :
+        'display_order' not in resultsFile.columns or\
+        (experiment.uploadType == "fromConcordance" and \
+        'Number of hit' not in resultsFile.columns):
         # if one of the previous columns are not in the file columns
         # return the following message
         return jsonify({"success": False, "message": "File format is not correct"})

--- a/rapidannotator/modules/home/views.py
+++ b/rapidannotator/modules/home/views.py
@@ -16,7 +16,6 @@ from matplotlib import pyplot as plt
 from io import BytesIO
 import base64
 from rapidannotator import app
-import io   
 import pandas as pd
 from rapidannotator.models import File
 
@@ -292,10 +291,10 @@ def _continueExperiment():
         and experiment.category != "text"\
         and not os.path.exists(experimentDir):
         os.makedirs(experimentDir)
-    # parse csv 
+    # parse csv format
     if fileExt == '.csv':
         resultsFile = pd.read_csv(resultsFile, sep=',')
-    # parse excel
+    # parse excel format
     else:
         resultsFile = pd.read_excel(resultsFile)
         pass
@@ -344,4 +343,4 @@ def _continueExperiment():
         concordance = resultsFile[columns[startConcordance:]]
         outfilePath = os.path.join(experimentDir, "concordance.csv")
         concordance.to_csv(outfilePath, index=False)
-    return jsonify({"success": True})
+    return jsonify({"success": True, "message": "Experiment created successfully."})


### PR DESCRIPTION
## Description
The following pull request adding is an adds-on to the current annotation process system to allow the experiment get more information about the data and use them with their process of information and features extraction and get more intuition about which part of the data is meant for this annotation
## Usage
This feature meant to be used by the experimenter in the step of modeling and preprocessing. 
## Screenshots
1. **Image experiments** [VIA](https://www.robots.ox.ac.uk/~vgg/software/via/) Vgg images annotators, I have integrated the images part to Rapid annotator
![image-via-adds-on](https://cdn.hashnode.com/res/hashnode/image/upload/v1628707729666/U115Ll0dK.gif?)

2. **Audio/Video** Built a time controller for selecting a time start and end of the video those controllers (buttons and [ion-slider](http://ionden.com/a/plugins/ion.rangeSlider/) manages the video running duration and starting and ending time
![video-audio-addson](https://user-images.githubusercontent.com/39674365/129346548-e7437d6d-532f-4d45-a701-9efc47d11a8e.gif)


3. **Text experiments** extended the current base highlighting feature of concordance to be able to use on the normal experiment also
![text-adds-on](https://cdn.hashnode.com/res/hashnode/image/upload/v1628706541496/g-bkyheBho.gif?auto=format,compress&gif-q=60&format=webm)
