### PR TITLE
Allowing users to import their own annotations levels without making it global (self-access)

### DIFF
--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -278,6 +278,7 @@ def _addAnnotationLevel():
                 description = annotationLevelForm.description.data,
                 instruction = annotationLevelForm.instruction.data,
                 multichoice = annotationLevelForm.multichoice.data,
+                labels_others = annotationLevelForm.labels_others.data,
             )
             if levelNumber:
                 annotationLevel.level_number = annotationLevelForm.levelNumber.data
@@ -423,6 +424,7 @@ def _editAnnotationLevel():
     annotationLevel.level_number = request.args.get('annotationLevelNumber', None)
     annotationLevel.instruction = request.args.get('annotationLevelInstruction', None)
     annotationLevel.multichoice = request.args.get('multichoice', None) == 'true'
+    annotationLevel.labels_others = request.args.get('labels_others', None) == 'true'
 
     db.session.commit()
     response = {}
@@ -504,10 +506,12 @@ def _importAnnotationtLevel(experimentId):
     myExperiments = Experiment.query.all()
 
     for experiment in myExperiments:
-        if experiment.is_global:
+        experiment_owners = experiment.owners.all()
+        current_user_is_owner = [owner for owner in experiment_owners if owner.id == current_user.id]
+        if experiment.is_global or current_user_is_owner :
             annotation_levels = experiment.annotation_levels
             global_annotation_level.append(annotation_levels)
-            owners.append(experiment.owners)
+            owners.append(experiment_owners)
             experiment_disp.append(experiment)
             import_id.append(experiment.id)
             global_names.append(experiment.globalName)

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -278,7 +278,6 @@ def _addAnnotationLevel():
                 description = annotationLevelForm.description.data,
                 instruction = annotationLevelForm.instruction.data,
                 multichoice = annotationLevelForm.multichoice.data,
-                labels_others = annotationLevelForm.labels_others.data,
             )
             if levelNumber:
                 annotationLevel.level_number = annotationLevelForm.levelNumber.data
@@ -424,7 +423,6 @@ def _editAnnotationLevel():
     annotationLevel.level_number = request.args.get('annotationLevelNumber', None)
     annotationLevel.instruction = request.args.get('annotationLevelInstruction', None)
     annotationLevel.multichoice = request.args.get('multichoice', None) == 'true'
-    annotationLevel.labels_others = request.args.get('labels_others', None) == 'true'
 
     db.session.commit()
     response = {}


### PR DESCRIPTION
### Description
Allowing the experiments' owners to import their annotation levels without doing the over-head step [make it global, import it then make it private again]
### Demo
![users-own-levels-import](https://user-images.githubusercontent.com/39674365/177140104-b74acae1-347e-4fa9-88c0-25712362c98c.gif)
