### PR TITLE
Enable/Disable advanced options in the experiment and fixed specific view

### DIFF
--- a/rapidannotator/models.py
+++ b/rapidannotator/models.py
@@ -272,6 +272,12 @@ class Experiment(db.Model):
         server_default='fcfs',
     )
 
+    advancedAnnotation = db.Column(
+        db.Boolean(name='advancedAnnotation'),
+        nullable=False,
+        server_default='0',
+    )
+
     """ One to One relation
     ..  For Audio / Video Experiments:
     ..  details of duration of the display time of the audio / video.

--- a/rapidannotator/modules/annotate_experiment/templates/annotate_experiment/main.html
+++ b/rapidannotator/modules/annotate_experiment/templates/annotate_experiment/main.html
@@ -104,6 +104,7 @@
 
 <div class="container annotationArea">
     <div class="row">
+        {%- if experiment.advancedAnnotation -%}
         {%- if experiment.category == 'image' -%}
         {{ icons() }}
           <span>
@@ -144,6 +145,7 @@
                 <span class='glyphicon glyphicon-info-sign my-tooltip' title="Instruction"> Please follow that structure of time [hh:mm:ss] for the inputs in case of you will modifiy them manually and step size is is in seconds</span>
                 <input placeholder="time step size in seconds i.e default is (0 s)" style="width:99%" type="number" min="0" id="time-step-size">
             </div>
+        {% endif %}
         {% endif %}
         <!-- the following 5 is preLoadLimit @ line 418-->
         {% for i in range(5) %}
@@ -918,7 +920,6 @@
             else {
                 currentFileCoordinates[levelId] = {"start":startTextIndex, "end":endTextIndex}
             }
-            //console.log(currentFileCoordinates)
             _ra_regions = [];
             _via_canvas_regions = [];
             var excessFiles = (preLoadedTill - currentLoadedFile + preLoadLimit) % preLoadLimit;

--- a/rapidannotator/modules/annotate_experiment/templates/annotate_experiment/specific.html
+++ b/rapidannotator/modules/annotate_experiment/templates/annotate_experiment/specific.html
@@ -1,19 +1,48 @@
 {% extends "annotate_experiment/base.html" %}
 {% from "macros.html" import render_field %}
+{% from "macros.html" import icons %}
 
 {% block title %} Specific Annotation Page {% endblock title %}
 {% block head %}
+<link rel="stylesheet" href="{{url_for('static', filename = 'css/via.css')}}">
+<link rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.3.1/css/ion.rangeSlider.min.css" />
+
   {{ super() }}
   <style type="text/css">
     .important { color: #336699; }
     .red {
         color: red;
     }
+    .hl { background: yellow; }
     
     span.hl { background: yellow; }
     * {
  	 	box-sizing: border-box;
 	}
+    .irs--modern .irs-from, .irs--modern .irs-to, .irs--modern .irs-single {
+        font-size:15px; !important
+    }
+    .time-range-slider{
+        margin-bottom:30px;
+    }
+    .time-range-control{
+        width:49%;
+    }
+    .time-control-btn{
+        width:24%;
+        margin:5px 0 5px 0;
+    }
+    audio, video{
+        width:98%;
+        margin-top:10px;
+    }
+    .irs--modern .irs-bar, .irs--modern .irs-line{
+        height: 15px;
+    }
+    .irs--modern .irs-handle > i:nth-child(2) {
+        height: 17px;
+    }
 
   </style>  
 {% endblock head %}
@@ -72,6 +101,84 @@
 
 <div class="container annotationArea">
     <div class="row">
+        {%- if experiment.advancedAnnotation -%}
+        {%- if experiment.category == 'image' -%}
+        {{ icons() }}
+        <span>
+            <div class="leftsidebar_accordion_panel show">
+                <ul class="region_shape">
+                    <li id="region_shape_none" class="selected" onclick="select_region_shape('none')" title="No select"><svg
+                            height="20" viewbox="0 0 24 24">
+                            <use xlink:href="#icon_pointer"></use>
+                        </svg></li>
+                    <li id="region_shape_rect" onclick="select_region_shape('rect')" title="Rectangle"><svg height="32"
+                            viewbox="0 0 32 32">
+                            <use xlink:href="#shape_rectangle"></use>
+                        </svg></li>
+                    <li id="region_shape_circle" onclick="select_region_shape('circle')" title="Circle"><svg height="32"
+                            viewbox="0 0 32 32">
+                            <use xlink:href="#shape_circle"></use>
+                        </svg></li>
+                    <li id="region_shape_ellipse" onclick="select_region_shape('ellipse')" title="Ellipse"><svg height="32"
+                            viewbox="0 0 32 32">
+                            <use xlink:href="#shape_ellipse"></use>
+                        </svg></li>
+                    <li id="region_shape_polygon" onclick="select_region_shape('polygon')" title="Polygon"><svg height="32"
+                            viewbox="0 0 32 32">
+                            <use xlink:href="#shape_polygon"></use>
+                        </svg></li>
+                    <li id="region_shape_point" onclick="select_region_shape('point')" title="Point"><svg height="32"
+                            viewbox="0 0 32 32">
+                            <use xlink:href="#shape_point"></use>
+                        </svg></li>
+                    <li id="region_shape_polyline" onclick="select_region_shape('polyline')" title="Polyline"><svg height="32"
+                            viewbox="0 0 32 32">
+                            <use xlink:href="#shape_polyline"></use>
+                        </svg></li>
+                    <li id="region_shape_sel_all_regions" onclick="sel_all_regions()" title="Select All Regions"> <svg
+                            height="32" viewbox="0 0 32 32">
+                            <use xlink:href="#icon_selectall"></use>
+                        </svg>
+                    <li id="region_shape_copy_sel_regions" onclick="copy_sel_regions()" title="Copy Regions"> <svg height="32"
+                            viewbox="0 0 32 32">
+                            <use xlink:href="#icon_copy"></use>
+                        </svg>
+                    <li id="region_shape_paste_sel_regions_in_current_image" onclick="paste_sel_regions_in_current_image()"
+                        title="Paste Regions"> <svg height="32" viewbox="0 0 32 32">
+                            <use xlink:href="#icon_paste"></use>
+                        </svg>
+                    <li id="region_shape_del_sel_regions" onclick="del_sel_regions()" title="Delete Region"> <svg height="32"
+                            viewbox="0 0 32 32">
+                            <use xlink:href="#icon_close"></use>
+                        </svg>
+                </ul>
+            </div>
+            <div id="message_panel" style="display:none;">
+                <div id="message_panel_content" class="content"></div>
+            </div>
+        </span>
+        {%elif experiment.category == 'audio' or experiment.category == 'video' %}
+        <div style="width:40%">
+            <div>
+                <input class="hidden-element time-range-slider" name="my_range" value="" />
+            </div>
+            <div>
+                <input class="time-range-control" placeholder="from" id="time-control-from">
+                <input class="time-range-control" placeholder="to" id="time-control-to">
+            </div>
+            <div>
+                <button class="time-control-btn" id="from-forward"> &raquo; </button>
+                <button class="time-control-btn" id="from-backward"> &laquo;</button>
+                <button class="time-control-btn" id="to-backward"> &laquo; </button>
+                <button class="time-control-btn" id="to-forward"> &raquo;</button>
+            </div>
+            <span class='glyphicon glyphicon-info-sign my-tooltip' title="Instruction"> Please follow that structure of time
+                [hh:mm:ss] for the inputs in case of you will modifiy them manually and step size is is in seconds</span>
+            <input placeholder="time step size in seconds i.e default is (0 s)" style="width:99%" type="number" min="0"
+                id="time-step-size">
+        </div>
+        {% endif %}
+        {% endif %}
         <div class="file col-xs-5 hidden-element" data-index="0" data-fileid=1>
             {%- if experiment.category == 'video' -%}
                 {%- if experiment.uploadType == 'NOTviaSpreadsheet' -%}
@@ -101,7 +208,13 @@
                 <a href="" id="sourceLink" target="_blank" style="margin-left:30%">Source Link</a>
                 {%- endif -%}
             {%- elif experiment.category == 'image' -%}
-                <img class="annotationWindow" src="" alt="">
+                <div style="width=400px; height:450px;">
+                    <div id="image_panel" class="display_area_content">
+                        <img class="annotationWindow" src="" alt="" id="region-image-0">
+                        <canvas id="region-canvas-0" width="350" height="420" tabindex="1">Sorry, your browser does not
+                            support HTML5 Canvas functionality which is required for this application.</canvas>
+                    </div>
+                </div>
             {%- elif experiment.category == 'text' -%}
                 <pre>
                 </pre>
@@ -209,7 +322,8 @@
 </div>
 
 
-
+<script src="{{url_for('static', filename = 'js/via.js')}}"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.3.1/js/ion.rangeSlider.min.js"></script>
 <script type="text/javascript">
     $(window).on('load', function() {
 
@@ -450,7 +564,6 @@
         function updateSelectedLabel(labelButton){
             var currentLevelBody = $(".annotationLevel[data-index='" + currentLevel +"']");
             var multichoice = currentLevelBody.data("multichoice"); // Used for multichoice labels for the current level
-            console.log(multichoice);
             levelId = currentLevelBody.data("levelid");
             selectedLabel = labelButton.data("labelid");
             if (multichoice == "True"){
@@ -510,6 +623,17 @@
         function nextLevelHandler(){
             currentLevelBody = $(".annotationLevel[data-index='" + currentLevel +"']");
             levelId = currentLevelBody.data("levelid");
+            if ("{{ experiment.category }}" === "video" || "{{ experiment.category }}" === "audio") {
+                currentFileCoordinates[levelId] = { "start": startTime, "end": endTime }
+            }
+            else if ("{{ experiment.category }}" === "image") {
+                currentFileCoordinates[levelId] = _ra_regions.map(e => e.shape_attributes)
+            }
+            else {
+                currentFileCoordinates[levelId] = { "start": startTextIndex, "end": endTextIndex }
+            }
+            _ra_regions = [];
+            _via_canvas_regions = [];
             already_submitted[levelId] = 1;
             multichoice = currentLevelBody.data("multichoice") == "True";
             currentLevelBody.addClass('hidden-element');
@@ -663,7 +787,7 @@
 
             var url = "{{ url_for('annotate_experiment._addAnnotationInfo')}}";
             var currentFileId = $(".file[data-index='" + currentLoadedFile + "']").data('fileid');
-
+            var coordinates = currentFileCoordinates || {};
             var data = {
                 'fileId' :          currentFileId,
                 'annotations' :     annotations, 
@@ -671,6 +795,7 @@
                 'labelCount' :     {{labelCount}},
                 'userId'    : "{{userId}}",
                 'hasToIncreaseCurrent': 1,
+                "coordinates": coordinates,
             };
 
             data = JSON.stringify(data);
@@ -747,7 +872,9 @@
             if("{{experiment.displayTargetCaption}}"){
                 $("#targetCaptionData").val(targetFileCaption);
             }
-
+            if ("{{experiment.category}}" === "text"){
+                updateHighlighting(startTextIndex, endTextIndex);
+            }
         }
 
         function updateFile(index, fileToLoad) {
@@ -819,7 +946,7 @@
         }
 
         function updateAnnotation(alreadyAnnotatedDict, levelId){
-                if(alreadyAnnotatedDict[levelId]) {
+                if(alreadyAnnotatedDict?.[levelId]) {
                     labels_names = [];
                     annotations[levelId] = {};
                     annotationsOrder[levelId] = [];
@@ -831,15 +958,259 @@
                         $(`input.label_other[data-labelid=${e[0]}]`).val(e[2]);
                         annotations[levelId][e[0]] = e[1];
                         annotationsOrder[levelId].push(e[0]);
+                        if ("{{ experiment.category }}" == "image") {
+                            _ra_regions = e[3]?.map(function (item, index) {
+                                return { "shape_attributes": { ...item}, "region_attributes": {} }
+                            }) || [];
+                            _via_show_img_from_buffer();
+                        }
+                        else if ("{{ experiment.category }}" == "audio" || "{{ experiment.category }}" == "video"){
+                                if (e[3]?.start && e[3]?.end){
+                                    restartTimeSlider(0, e[3]?.start, e[3]?.end);
+                                } else {
+                                    restartTimeSlider(0);
+                                }
+                        } else if ("{{ experiment.category }}" == "text"){
+                            startTextIndex = e[3]?.start;
+                            endTextIndex = e[3]?.end;
+                            updateHighlighting(startTextIndex, endTextIndex);
+                        }
                     });
                     textAlreadyAnnotated = "Currently selected label/s:" + "<b>"+ labels_names +"</b>";
                     $('.alreadyAnnotated').html(textAlreadyAnnotated);
+                } else {
+                    restartTimeSlider(0);
                 }
+        }
+        function updateHighlighting(start, end){
+            if ("{{ experiment.uploadType }}" !== "fromConcordance")
+                highlightElementText(".file[data-index='" + currentLoadedFile + "'] pre", start, end);
+            else 
+                highlightElementText(".fileCaption h4", start, end);
+        }
+        function textHighlightingInit() {
+            if ("{{ experiment.uploadType }}" !== "fromConcordance"
+                && "{{ experiment.category }}" === "text")
+                thisRespondHightlightText(".file[data-index='" + currentLoadedFile + "'] pre");
+            else if ("{{ experiment.category }}" === "text") 
+                thisRespondHightlightText(".fileCaption h4");
+        }
+        // UI controllers for audio/video experiment
+        $("#from-forward").on("click", function () { updateTimeInput("from", 1) });
+        $("#from-backward").on("click", function () { updateTimeInput("from", -1) });
+        $("#to-forward").on("click", function () { updateTimeInput("to", 1) });
+        $("#to-backward").on("click", function () { updateTimeInput("to", -1) });
+
+        function updateTimeInput(name, sign) {
+            var stepInputValue = +$("#time-step-size").val();
+            var step = isNaN(stepInputValue) ? 1 : stepInputValue;
+            var element = $(`#time-control-${name}`);
+            var oldValue = element.val();
+            var splitted = oldValue.split(":").map(e => +e);
+            var h2s = splitted[0] * 3600 // hours to seconds
+            var m2s = splitted[1] * 60 // minutes to seconds
+            var s2s = splitted[2] // string seconds to number seconds
+            oldValue = 0;
+            if (!isNaN(h2s))
+                oldValue += h2s;
+            if (!isNaN(m2s))
+                oldValue += m2s;
+            if (!isNaN(s2s))
+                oldValue += s2s;
+
+            var newValue = oldValue + (sign * step);
+            if (name == "from" && endTime < newValue) {
+                return
             }
-            
+            else if (name == "to" && startTime > newValue) {
+                return
+            }
+            if (newValue < 0) newValue = 0;
+            if (name == "to" && newValue > media.duration) newValue = media.duration;
+            var myRange = $(".time-range-slider").data("ionRangeSlider");
+            myRange.update({
+                [name]: newValue
+            })
+            onChangeSliderHandler({ to: myRange.old_to, from: myRange.old_from });
+            element.val(hhmmsss_prettify(newValue));
+            //updateSlider();
+        }
+        function restartTimeSlider(fileIndex, start, end) {
+            mediaFileIndex = fileIndex
+            timerEntryCount = 0;
+            if ("{{ experiment.category }}" == "video" || "{{ experiment.category }}" == "audio") {
+                sliderTimer = setTimeout(()=>(initSlider(start, end)), retySliderLoadDelay);
+            }
+        }
+        function replayVideo() {
+            media.pause();
+            var looping = loopingButton.val();
+            if (looping == "True")
+                setTimeout(() => { media.currentTime = startTime; media.play(); }, loopingDelay)
+        }
+        // [RAVAs] Setting up the slider 
+        function initSlider(start, end) {
+            timerEntryCount += 1;
+            if ("{{ experiment.category }}" == "video")
+                media = $(".file[data-index='" + mediaFileIndex + "'] video")[0];
+            else
+                media = $(".file[data-index='" + mediaFileIndex + "'] audio")[0];
+            if (!isNaN(media.duration)) {
+                mediaSrc = media.src;
+                updateSlider(media, start, end);
+                media.addEventListener("timeupdate", function () {
+                    if (media.currentTime >= endTime) {
+                        replayVideo();
+                    }
+                }, false);
+                clearTimeout(sliderTimer);
+                media.addEventListener('ended', replayVideo, false);
+            }
+            else if (timerEntryCount < maxLoadingTime) {
+                clearTimeout(sliderTimer);
+                sliderTimer = setTimeout(()=>initSlider(start, end), retySliderLoadDelay);
+            }
+        }
+
+        // [RAVAs] Updating the slider
+        function updateSlider(media, initStart, initEnd) {
+            var myRange = $(".time-range-slider").data("ionRangeSlider");
+            if (myRange) {
+                myRange.destroy();
+            }
+            if (initStart && initEnd) {
+                startTime = initStart;
+                endTime = initEnd;
+            }
+            else {
+                startTime = 0;
+                endTime = media.duration;
+            }
+            rangeSlider.ionRangeSlider({
+                type: "double",
+                skin: "modern",
+                min: 0.0,
+                max: media.duration,
+                max_interval: media.duration,
+                step: 0.001,
+                from: startTime,
+                to: endTime,
+                drag_interval: true,
+                grid: false,
+                prettify: hhmmsss_prettify,
+                onChange: onChangeSliderHandler
+            });
+            myRange = $(".time-range-slider").data("ionRangeSlider");
+            myRange.update({
+                from: startTime,
+                to: endTime,
+            })
+            fromInput.val(hhmmsss_prettify(startTime));
+            toInput.val(hhmmsss_prettify(endTime));
+        }
+        function onChangeSliderHandler(data) {
+            if (!isNaN(media.duration)) {
+                media.currentTime = data.from;
+                startTime = data.from;
+                endTime = data.to;
+                fromInput.val(hhmmsss_prettify(data.from));
+                toInput.val(hhmmsss_prettify(data.to));
+                media.play();
+            }
+        }
+        // [RAVAs] Utility for time representation on the slider
+        function hhmmsss_prettify(n) {
+            var time = parseFloat(n) * 1000.0;
+            return new Date(time).toISOString().substr(11, 11)
+        }
+        ////////////////////////////////////////////////////////////////////////////
+        function highlightElementText(element, start, end) {
+            var text = $(element).text();
+            var before = text.substring(0, start);
+            var highlighted = text.substring(start, end);
+            var after = text.substring(end);
+            $(element).html(before + "<span class='hl'>" + highlighted + "</span>" + after);
+        }
+        function unhighlightElement(element, start, end) {
+            var text = $(element).text();
+            var before = text.substring(0, start);
+            var highlighted = text.substring(start, end);
+            var after = text.substring(end);
+            $(element).html(before + highlighted + after);
+        }
+        // Text selection/highlighting 
+        function thisRespondHightlightText(thisDiv) {
+            if ($(thisDiv).attr('listener')) return;
+            $(thisDiv).attr('listener', 'true');
+            $(thisDiv).on("mouseup", function () {
+                selectedText = getSelectionText();
+                var replacement = $('<span></span>').attr({ 'class': 'hl' }).html(selectedText);
+                var replacementHtml = $('<div>').append(replacement.clone()).remove().html();
+                var text = $(this).text().replace(selectedText, replacementHtml);
+                $(this).html(text);
+                $("#targetCaptionData").val(selectedText);
+            });
+            $(thisDiv).mouseup();
+        }
+        function obtainSelectionCoords(start, end) {
+            startTextIndex = start;
+            endTextIndex = end;
+            if (startTextIndex > endTextIndex) {
+                var temp = startTextIndex;
+                startTextIndex = endTextIndex;
+                endTextIndex = temp;
+            }
+        }
+        function getSelectionText(preStart, preEnd) {
+            var text = "";
+            if (window.getSelection) {
+                text = window.getSelection().toString();
+                var start = window.getSelection().anchorOffset || preStart;
+                var end = window.getSelection().focusOffset || preEnd;
+                obtainSelectionCoords(start, end)
+                if (start == end && text.length > 0 || Math.abs(start - end) == 1 && text.length > 1)
+                    text = ""
+            } else if (document.selection && document.selection.type != "Control") {
+                text = document.selection.createRange().text;
+                var start = document.selection().anchorOffset
+                var end = document.selection().focusOffset
+                obtainSelectionCoords(start, end)
+                if (start == end && text.length > 0 || Math.abs(start - end) == 1 && text.length > 1)
+                    text = ""
+            }
+            return text;
+        }
         var currentLevelBody = $(".annotationLevel[data-index='" + currentLevel +"']");
         var levelId = currentLevelBody.data("levelid");
         var alreadyAnnotatedDict = {{annotationAlreadyDone | safe}};
+        var currentFileCoordinates = {}
+        if ("{{ experiment.category }}" == "image") {
+                _ra_via_init(1);
+        } else if ("{{ experiment.category }}" == "text") {
+                textHighlightingInit();
+        } 
+        ////////////////////////////////////////////////////////////////////////////
+        // [RAVAs]: Rapid Annotator Text highlighting 
+        // Variables for text highlighting for text selection
+        var startTextIndex = 0;
+        var endTextIndex = 0;
+        var selectedText = "";
+
+        ////////////////////////////////////////////////////////////////////////////
+        // [RAVAs]: Rapid Annotator Video Audio slider
+        // Variables for Audio/Video media time range selection
+        var startTime, endTime, timerEntryCount = 0;
+        var media, sliderTimer, mediaEndedTimer;
+        var fromInput = $("#time-control-from");
+        var toInput = $("#time-control-to");
+        var rangeSlider = $(".time-range-slider");
+        rangeSlider.ionRangeSlider({ type: "double", skin: "modern", "from": 0, "to": 0, "min": 0, max: 0 });
+        var mediaFileIndex = 0;
+        var mediaSrc = ""
+        const loopingDelay = 500 // in ms
+        const maxLoadingTime = 40;
+        const retySliderLoadDelay = 200;
+    
         updateAnnotation(alreadyAnnotatedDict, levelId);
     });
 
@@ -878,30 +1249,6 @@
         };
     });
     
-    if("{{experiment.displayTargetCaption}}"){
-        thisRespondHightlightText(".fileCaption h4");
-    }
-
-    function thisRespondHightlightText(thisDiv){
-        $(thisDiv).on("mouseup", function () {
-            var selectedText = getSelectionText();
-            var replacement = $('<span></span>').attr({'class':'hl'}).html(selectedText);
-            var replacementHtml = $('<div>').append(replacement.clone()).remove().html();
-            var text = $(this).text().replace(selectedText, replacementHtml);
-            $(this).html(text);
-            $("#targetCaptionData").val(selectedText);
-        });
-    }
-
-    function getSelectionText() {
-        var text = "";
-        if (window.getSelection) {
-            text = window.getSelection().toString();
-        } else if (document.selection && document.selection.type != "Control") {
-            text = document.selection.createRange().text;
-        }
-        return text;
-    }
 </script>
 
 {% endblock annotate_experiment_body %}

--- a/rapidannotator/modules/annotate_experiment/views.py
+++ b/rapidannotator/modules/annotate_experiment/views.py
@@ -543,7 +543,7 @@ def specificAnnotation(userId, experimentId, fileId):
         label = Label.query.filter_by(id=info.label_id).first()
         if not annotationAlreadyDone.get(info.annotationLevel_id, None):
             annotationAlreadyDone[info.annotationLevel_id] = []
-        annotationAlreadyDone[info.annotationLevel_id].append([info.label_id, label.name, info.label_other])
+        annotationAlreadyDone[info.annotationLevel_id].append([info.label_id, label.name, info.label_other, info.coordinates or []])
 
     isExpowner =  int((current_user in  experiment.owners))
 

--- a/rapidannotator/modules/home/forms.py
+++ b/rapidannotator/modules/home/forms.py
@@ -65,6 +65,11 @@ class AddExperimentForm(FlaskForm):
                     ('random', 'random')],
     )
 
+    advancedAnnotation = BooleanField(
+        label=_('Advanced Annotation'),
+        description=_("Check if you want to enable advanced annotation."),
+    )
+
     def validate_name(self, name):
         experiment = Experiment.query.filter_by(name=name.data).first()
         if experiment is not None:

--- a/rapidannotator/modules/home/views.py
+++ b/rapidannotator/modules/home/views.py
@@ -67,6 +67,7 @@ def addExperiment():
             category=addExperimentForm.category.data,
             uploadType=addExperimentForm.uploadType.data,
             displayType=addExperimentForm.displayType.data,
+            advancedAnnotation=addExperimentForm.advancedAnnotation.data,
         )
         experiment.owners.append(current_user)
         db.session.add(experiment)
@@ -282,7 +283,7 @@ def _continueExperiment():
         return jsonify({"success": False, "message": "File extension not allowed"})
     # create new experiment
     newExperiment = Experiment(name=expName, description=description, \
-            category=experiment.category,uploadType=experiment.uploadType,\
+            category=experiment.category,uploadType=experiment.uploadType, advancedAnnotation=experiment.advancedAnnotation,\
                 status="In Progress", is_done=False)
     newExperiment.owners.append(current_user)
     db.session.add(newExperiment)


### PR DESCRIPTION
That PR contains two main additions 
- A new configuration to the experiment to control whether you want to add the new features those added last year in that PR #60 
so, at the adding new experiment we get a new field for the experiment's table called *advanced annotation* and at the creation of the experiment it appears as a checkbox.  

![image](https://user-images.githubusercontent.com/39674365/200314909-464a549c-1f9b-4171-9c0c-cccbb6c37137.png)

- At viewing a specific entry of the experiment files (the advanced features above were missing from that view, so they have been added and are being loaded and edited also from specific annotation view) 
(Example of before and after at an image category experiment)

After            |  Before 
:-------------------------:|:-------------------------:
![example_after](https://user-images.githubusercontent.com/39674365/200315936-711b7e47-5a20-4dad-a45e-af518ae39eb5.gif)  |  ![example_before](https://user-images.githubusercontent.com/39674365/200316144-5556c1bc-7a5c-4694-a222-0bce6826b352.gif)
