### PR TITLE
New results type of grouped annotations elan files at [ELAN experiment] and some updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Please refer the following links to install the Rapid Annotator-2.0 .
 ## Contributers from Google Summer of Code
 - [Vaibhav Gupta](https://github.com/damnOblivious) @ [2018](https://damnoblivious.github.io/GSoC-Blog/)
 - [Gulshan Kumar](https://github.com/gulshan-mittal) @ [2019](https://gulshan-mittal.github.io/GSoC19-Blog/) and [2020](https://gulshan-mittal.github.io/GSoC20-Blog/)
-- [Mohamed Mokhtar](https://github.com/rrrokhtar) @ [2021](https://rrrokhtar.github.io/rapid-annotator/21/) and [2022](https://rrrokhtar.github.io/rapid-annotator/22/)
+- [Mohamed Mokhtar](https://github.com/rrrokhtar) @ [2021](https://rrrokhtar.github.io/rapid-annotator/21) and [2022](https://rrrokhtar.github.io/rapid-annotator/22)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Please refer the following links to install the Rapid Annotator-2.0 .
 ## Contributers from Google Summer of Code
 - [Vaibhav Gupta](https://github.com/damnOblivious) @ [2018](https://damnoblivious.github.io/GSoC-Blog/)
 - [Gulshan Kumar](https://github.com/gulshan-mittal) @ [2019](https://gulshan-mittal.github.io/GSoC19-Blog/) and [2020](https://gulshan-mittal.github.io/GSoC20-Blog/)
-- [Mohamed Mokhtar](https://github.com/rrrokhtar) @ [2021](https://rrrokhtar.github.io/rapid-annotator-21/)
+- [Mohamed Mokhtar](https://github.com/rrrokhtar) @ [2021](https://rrrokhtar.github.io/rapid-annotator/21/) and [2022](https://rrrokhtar.github.io/rapid-annotator/22/)
 
 ## Contributing
 

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/main.html
@@ -728,7 +728,7 @@
 
         category = "{{ experiment.category }}";
         dt = "{{ experiment.display_time }}";
-        if( dt == "None" && (category  === "audio" || category === "video") ) {
+        if( dt == "None" && (category  === "audio" || category === "video" || category === "elan") ) {
             setDisplayTime(2, 2);
             // $('#displayTimeModalId').modal('show');
         }

--- a/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
+++ b/rapidannotator/modules/add_experiment/templates/add_experiment/settings.html
@@ -104,7 +104,7 @@
             </ul>
         </div>
 
-        {%- if (experiment.category == 'audio' or experiment.category == 'video') -%}
+        {%- if (experiment.category == 'audio' or experiment.category == 'video' or experiment.category == 'elan') -%}
             <a data-toggle="modal" data-target="#displayTimeModalId"
                 class="changeDisplayTime btn btn-primary btn-group btn-group-inline btn-space">{{ ('Display Time') }}
             </a>
@@ -976,7 +976,7 @@
         category = "{{ experiment.category }}";
         uploadType = "{{experiment.uploadType}}";
         dispTime = "{{ experiment.display_time }}";
-        if( dispTime == "None" &&  uploadType != "manual" && (category  === "audio" || category === "video") ) {
+        if( dispTime == "None" &&  uploadType != "manual" && (category  === "audio" || category === "video" || category === "elan") ) {
             $('#displayTimeModalId').modal('show');
         }
 

--- a/rapidannotator/modules/add_experiment/views.py
+++ b/rapidannotator/modules/add_experiment/views.py
@@ -769,7 +769,7 @@ def addFilesFromConcordance(experimentId, concordance):
         for row in reader:
             caption = row["Context before"] + " " + row["Query item"] +  " " + row["Context after"]
             target_caption = row["Query item"]
-            if experiment.category == "video":
+            if experiment.category == "video" or experiment.category == "elan":
                 content = row["Video Snippet"]
             elif experiment.category == "audio":
                 content = row["Audio Snippet"]

--- a/rapidannotator/modules/elan/templates/elan/main.html
+++ b/rapidannotator/modules/elan/templates/elan/main.html
@@ -164,7 +164,11 @@
       <div id="annotationContent">
         <div id="player" class="content-entry">
           <video class="clip" id="video" width="400" controls>
-            {% set videoUrl = "/annotate_experiment/uploads/" + experiment.id|string + "/" + currentFile.get('content', '')%}
+            {% if experiment.uploadType == 'fromConcordance' %}
+            {% set videoUrl = currentFile.content%}
+            {% else %}
+            {% set videoUrl = "/annotate_experiment/uploads/" + experiment.id|string + "/" + currentFile.get('content', '') %}
+            {% endif %}
             <source src={{ videoUrl }} type="video/mp4"/>
             Your browser does not support HTML5 video.
           </video>
@@ -317,7 +321,10 @@
                     }
                     currentFile = response['currentFile'];
                     currentFileIndex = response['currentFileIndex'];
-                    videoUrl = "/annotate_experiment/uploads/" + "{{experiment.id|string}}" + "/" + currentFile?.content;
+                    videoUrl = currentFile?.content;
+                    if ("{{experiment.uploadType}}" != "fromConcordance") {
+                      videoUrl = "/annotate_experiment/uploads/" + "{{experiment.id|string}}" + "/" + videoUrl;
+                    }
                     timeline.videoElement.src = videoUrl;
                     updateProgressbar(currentFileIndex);
                     // messages control

--- a/rapidannotator/modules/elan/templates/elan/main.html
+++ b/rapidannotator/modules/elan/templates/elan/main.html
@@ -164,8 +164,8 @@
       <div id="annotationContent">
         <div id="player" class="content-entry">
           <video class="clip" id="video" width="400" controls>
-            {% if experiment.uploadType == 'fromConcordance' %}
-            {% set videoUrl = currentFile.content%}
+            {% if experiment.uploadType == 'fromConcordance' or experiment.uploadType == "viaSpreadsheet"%}
+            {% set videoUrl = currentFile.content %}
             {% else %}
             {% set videoUrl = "/annotate_experiment/uploads/" + experiment.id|string + "/" + currentFile.get('content', '') %}
             {% endif %}

--- a/rapidannotator/modules/elan/templates/elan/main.html
+++ b/rapidannotator/modules/elan/templates/elan/main.html
@@ -164,12 +164,7 @@
       <div id="annotationContent">
         <div id="player" class="content-entry">
           <video class="clip" id="video" width="400" controls>
-            {% if experiment.uploadType == 'fromConcordance' or experiment.uploadType == "viaSpreadsheet"%}
-            {% set videoUrl = currentFile.content %}
-            {% else %}
-            {% set videoUrl = "/annotate_experiment/uploads/" + experiment.id|string + "/" + currentFile.get('content', '') %}
-            {% endif %}
-            <source src={{ videoUrl }} type="video/mp4"/>
+            <source type="video/mp4"/>
             Your browser does not support HTML5 video.
           </video>
         </div>
@@ -296,6 +291,11 @@
         }
         checkLabelWarning();
         checkThanksNote();  
+        if ("{{experiment.uploadType}}" == 'fromConcordance' || "{{experiment.uploadType}}" == "viaSpreadsheet")
+            videoUrl = getVideoUrl(currentFile.content, before_time="{{experiment.display_time.before_time}}", after_time="{{experiment.display_time.after_time}}");
+        else 
+            videoUrl = "/annotate_experiment/uploads/" + "{{experiment.id|string}}" + "/" + currentFile.content
+        timeline.videoElement.src = videoUrl;
         undoButton.on('click', function() {
             timeline.videoElement.style.display = 'unset';
             timeline.canvas.style.display = "unset";
@@ -321,9 +321,10 @@
                     }
                     currentFile = response['currentFile'];
                     currentFileIndex = response['currentFileIndex'];
-                    videoUrl = currentFile?.content;
                     if ("{{experiment.uploadType}}" != "fromConcordance") {
-                      videoUrl = "/annotate_experiment/uploads/" + "{{experiment.id|string}}" + "/" + videoUrl;
+                      videoUrl = "/annotate_experiment/uploads/" + "{{experiment.id|string}}" + "/" + currentFile.content;
+                    } else {
+                      videoUrl = getVideoUrl(currentFile.content, before_time="{{experiment.display_time.before_time}}", after_time="{{experiment.display_time.after_time}}")
                     }
                     timeline.videoElement.src = videoUrl;
                     updateProgressbar(currentFileIndex);
@@ -365,7 +366,11 @@
                         checkThanksNote();
                         checkLabelWarning();
                     } else {
-                        videoUrl = "/annotate_experiment/uploads/" + "{{experiment.id|string}}" + "/" + currentFile?.content;
+                        if ("{{experiment.uploadType}}" != "fromConcordance") {
+                          videoUrl = "/annotate_experiment/uploads/" + "{{experiment.id|string}}" + "/" + currentFile.content;
+                        } else {
+                          videoUrl = getVideoUrl(currentFile.content, before_time="{{experiment.display_time.before_time}}", after_time="{{experiment.display_time.after_time}}")
+                        }
                         timeline.videoElement.src = videoUrl;
                         var annotations = response['annotations'];
                         {% for level in experiment.annotation_levels | sort(attribute='level_number')%}
@@ -380,6 +385,24 @@
                 }
             }); 
         });
+
+        function getVideoUrl(content, before_time, after_time) {
+          var temp_list = content.split("&");
+					var temp_starttime = (temp_list[1]).split("=");
+          var before_time = 0;
+          var after_time = 0;
+					if ("{{ experiment.display_time.before_time }}") {
+						var before_time = parseFloat("{{ experiment.display_time.before_time }}");
+					}
+					var starttime = parseFloat(temp_starttime[1]) - before_time;
+					if (starttime < 0) {starttime = 0;}
+					var temp_endtime = (temp_list[2]).split("=");
+					if ("{{ experiment.display_time.after_time }}") {
+						var after_time = parseFloat("{{ experiment.display_time.after_time }}");
+					}
+					var endtime = parseFloat(temp_endtime[1]) + after_time;
+					return temp_list[0] + "&start=" + starttime.toString() + "&end=" + endtime.toString();
+        }
 
         // Create key binding keys for the experiment's annotation tiers
         var tiersBindingKeys = {};

--- a/rapidannotator/modules/elan/templates/elan/results.html
+++ b/rapidannotator/modules/elan/templates/elan/results.html
@@ -64,19 +64,23 @@
         </a>
         {%- set exportResultsUrlCSV = url_for('elan.exportResults', experimentId = experiment.id, exportType="csv") %}
         {%- set exportResultsUrlXLSX = url_for('elan.exportResults', experimentId = experiment.id, exportType="xlsx") %}
+        {%- set exportResultsUrlZIP = url_for('elan.downloadAllEafResults', experimentId = experiment.id) %}
         <div class="dropdown btn-group btn-group-inline btn-space">
           <button class="btn btn-primary dropdown-toggle"
                   type="button"
-                  id="addOwners"
+                  id="DownloadResultsOptions"
                   data-toggle="dropdown">
             {{ ('Download Results') }}
             <span class="glyphicon glyphicon-download-alt"></span> &nbsp;
             <span class="caret"></span>
           </button>
           <ul class="dropdown-menu scrollable-dropdown"
-              id="addOwnersMenu"
+              id="DownloadResultsOptions"
               role="menu"
-              aria-labelledby="addOwners">
+              aria-labelledby="DownloadResultsOptions">
+            <li role="presentation">
+              <a role="menuitem" tabindex="-1" href="{{ exportResultsUrlZIP }}"><span>Download all annotations as ZIP</span></a>
+            </li>
             <li role="presentation">
               <a role="menuitem" tabindex="-1" href="{{ exportResultsUrlCSV }}"><span>Download as csv</span></a>
             </li>

--- a/rapidannotator/modules/elan/templates/elan/results.html
+++ b/rapidannotator/modules/elan/templates/elan/results.html
@@ -64,7 +64,8 @@
         </a>
         {%- set exportResultsUrlCSV = url_for('elan.exportResults', experimentId = experiment.id, exportType="csv") %}
         {%- set exportResultsUrlXLSX = url_for('elan.exportResults', experimentId = experiment.id, exportType="xlsx") %}
-        {%- set exportResultsUrlZIP = url_for('elan.downloadAllEafResults', experimentId = experiment.id) %}
+        {%- set exportResultsUrlZIPVideosAttached = url_for('elan.downloadAllEafResults', experimentId = experiment.id, includeVideos=1) %}
+        {%- set exportResultsUrlZIPVideosNotAttached = url_for('elan.downloadAllEafResults', experimentId = experiment.id, includeVideos=0) %}
         <div class="dropdown btn-group btn-group-inline btn-space">
           <button class="btn btn-primary dropdown-toggle"
                   type="button"
@@ -79,7 +80,10 @@
               role="menu"
               aria-labelledby="DownloadResultsOptions">
             <li role="presentation">
-              <a role="menuitem" tabindex="-1" href="{{ exportResultsUrlZIP }}"><span>Download all annotations as ZIP</span></a>
+              <a role="menuitem" tabindex="-1" href="{{ exportResultsUrlZIPVideosAttached }}"><span>Annotations with videos as ZIP</span></a>
+            </li>
+            <li role="presentation">
+              <a role="menuitem" tabindex="-1" href="{{ exportResultsUrlZIPVideosNotAttached }}"><span>Annotations without videos as ZIP</span></a>
             </li>
             <li role="presentation">
               <a role="menuitem" tabindex="-1" href="{{ exportResultsUrlCSV }}"><span>Download as csv</span></a>

--- a/rapidannotator/modules/elan/templates/elan/specific.html
+++ b/rapidannotator/modules/elan/templates/elan/specific.html
@@ -136,7 +136,7 @@
         <div id="annotationContent">
           <div id="player" class="content-entry">
             <video class="clip" id="video" width="400" controls>
-              {% if experiment.uploadType == 'fromConcordance' %}
+              {% if experiment.uploadType == 'fromConcordance' or experiment.uploadType == 'viaSpreadsheet' %}
               {% set videoUrl = currentFile.content%}
               {% else %}
               {% set videoUrl = "/annotate_experiment/uploads/" + experiment.id|string + "/" + currentFile.get('content', '') %}

--- a/rapidannotator/modules/elan/templates/elan/specific.html
+++ b/rapidannotator/modules/elan/templates/elan/specific.html
@@ -136,7 +136,11 @@
         <div id="annotationContent">
           <div id="player" class="content-entry">
             <video class="clip" id="video" width="400" controls>
-              {% set videoUrl = "/annotate_experiment/uploads/" + experiment.id|string + "/" + currentFile.get('content', '')%}
+              {% if experiment.uploadType == 'fromConcordance' %}
+              {% set videoUrl = currentFile.content%}
+              {% else %}
+              {% set videoUrl = "/annotate_experiment/uploads/" + experiment.id|string + "/" + currentFile.get('content', '') %}
+              {% endif %}
               <source src={{ videoUrl }} type="video/mp4" />
               Your browser does not support HTML5 video.
             </video>

--- a/rapidannotator/modules/elan/templates/elan/specific.html
+++ b/rapidannotator/modules/elan/templates/elan/specific.html
@@ -136,12 +136,7 @@
         <div id="annotationContent">
           <div id="player" class="content-entry">
             <video class="clip" id="video" width="400" controls>
-              {% if experiment.uploadType == 'fromConcordance' or experiment.uploadType == 'viaSpreadsheet' %}
-              {% set videoUrl = currentFile.content%}
-              {% else %}
-              {% set videoUrl = "/annotate_experiment/uploads/" + experiment.id|string + "/" + currentFile.get('content', '') %}
-              {% endif %}
-              <source src={{ videoUrl }} type="video/mp4" />
+              <source type="video/mp4" />
               Your browser does not support HTML5 video.
             </video>
           </div>
@@ -226,6 +221,11 @@
     $(window).on('load', function() {      
         var currentFile = {{ currentFile|tojson|safe }};
         var saveButton = $('#saveButton');
+        if ("{{experiment.uploadType}}" == 'fromConcordance' || "{{experiment.uploadType}}" == "viaSpreadsheet")
+            videoUrl = getVideoUrl(currentFile.content, before_time="{{experiment.display_time.before_time}}", after_time="{{experiment.display_time.after_time}}");
+        else 
+            videoUrl = "/annotate_experiment/uploads/" + "{{experiment.id|string}}" + "/" + currentFile.content
+        timeline.videoElement.src = videoUrl;
         saveButton.on('click', function(){
             var newAnnotations = timeline.tracks.reduce((acc, track) => {acc[track.id] = track.annotations; return acc;}, {});
             var url = "{{ url_for('elan.addAnnotation')}}";
@@ -284,7 +284,25 @@
             event.preventDefault();
 
         });
-
+        
+      function getVideoUrl(content, before_time, after_time) {
+          var temp_list = content.split("&");
+					var temp_starttime = (temp_list[1]).split("=");
+          var before_time = 0;
+          var after_time = 0;
+					if ("{{ experiment.display_time.before_time }}") {
+						var before_time = parseFloat("{{ experiment.display_time.before_time }}");
+					}
+					var starttime = parseFloat(temp_starttime[1]) - before_time;
+					if (starttime < 0) {starttime = 0;}
+					var temp_endtime = (temp_list[2]).split("=");
+					if ("{{ experiment.display_time.after_time }}") {
+						var after_time = parseFloat("{{ experiment.display_time.after_time }}");
+					}
+					var endtime = parseFloat(temp_endtime[1]) + after_time;
+					return temp_list[0] + "&start=" + starttime.toString() + "&end=" + endtime.toString();
+      }
+      
       function displayMessage(message){
             var snackbar = $('#snackbar');
             snackbar.text(message)

--- a/rapidannotator/modules/elan/views.py
+++ b/rapidannotator/modules/elan/views.py
@@ -349,7 +349,7 @@ def createEafXML(experiment, file, annotations, author):
     MEDIA_TYPE = 'video'
     MIME_TYPE = 'video/mp4'
     RELATIVE_MEDIA_URL = "file://./{}".format(file.name+".mp4")
-    if experiment.uploadType != "fromConcordance":
+    if experiment.uploadType == "manual":
         RELATIVE_MEDIA_URL = "file://./{}".format(file.name)
     # Root element
     eaf = etree.Element('ANNOTATION_DOCUMENT', AUTHOR=author, FORMAT=FORMAT, VERSION=VERSION, DATE=DATE)
@@ -522,7 +522,7 @@ def createEafGroupedXML(experiment, file, annotations, annotators):
     MEDIA_TYPE = 'video'
     MIME_TYPE = 'video/mp4'
     RELATIVE_MEDIA_URL = "file://./{}".format(file.name+".mp4")
-    if experiment.uploadType != "fromConcordance":
+    if experiment.uploadType == "manual":
         RELATIVE_MEDIA_URL = "file://./{}".format(file.name)
     # Root element
     eaf = etree.Element('ANNOTATION_DOCUMENT', FORMAT=FORMAT, VERSION=VERSION, DATE=DATE)
@@ -625,7 +625,7 @@ def downloadAllEafResults(experimentId, includeVideos=0):
             zip.writestr(file.name + '.eaf', eafBytes.getvalue())
             if includeVideos:
                 video = None
-                if experiment.uploadType == 'fromConcordance':
+                if experiment.uploadType == 'fromConcordance' or experiment.uploadType == 'viaSpreadsheet':
                 # Download the video snippet
                     try:
                         video = requests.get(file.content)


### PR DESCRIPTION
### Description
That pull request contains the following mainly:
#### New type of results' exporting at elan experiment 
It is simply a **ZIP** file contains the grouped annotations of **all files**; the exported results will be a compressed file; **experiment_name.zip** contains all experiment's files; each file is similar to the following.
`**Recalling**`; each grouped annotation file contains the annotations of all users to that file and each of them is represented as a single tier for example, an experiment has two tiers (t1 and t2) and three annotators (a1, a2 and a3) and 3 files (f1, f2 and f3);  

The exported results will be zip file contains:
- f1.eaf
- f2.eaf
- f3.eaf

Each elan file will be containing tiers as the following
- t1 (a1)
- t2 (a1)
- t1 (a2)
- t2 (a2)
- t1 (a3)
- t2 (a3)

#### Demo
![prdemo](https://user-images.githubusercontent.com/39674365/203347065-6c02c8b1-ade9-4220-bbc8-e64c9f167ad4.gif)

#### Some side changes
- README.md updated with the new links of GSOC-22 and changed CSOC-21
- Some changed at the current results' code changed "send_file" to "Response" because it has changed, so to keep old-version compatibility replaced with Response.
Flask : [`Changed in version 2.0: download_name replaces the attachment_filename parameter. If as_attachment=False, it is passed with Content-Disposition: inline instead. `](https://flask.palletsprojects.com/en/2.2.x/api/)
 - Changed an id name to the correct logical name